### PR TITLE
slider.animatingTo

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -23,6 +23,7 @@
       slider.count = slider.slides.length;
       slider.animating = false;
       slider.currentSlide = slider.vars.slideToStart;
+      slider.animatingTo = slider.currentSlide;
       slider.atEnd = (slider.currentSlide == 0) ? true : false;
       slider.eventType = ('ontouchstart' in document.documentElement) ? 'touchstart' : 'click';
       slider.cloneCount = 0;
@@ -295,6 +296,7 @@
         }
         
         //FlexSlider: before() animation Callback
+        slider.animatingTo = target;
         slider.vars.before(slider);
         
         if (slider.vars.animation.toLowerCase() == "slide") {


### PR DESCRIPTION
This is just a small update to include a slider.animatingTo property in the callback API. I needed to expose the target variable when using the before() callback, so I could get the index of the upcoming slide. I would have just used slider.getTarget(), but I needed the index from clicks on the control nav, too.

Maybe this is helpful for someone else, too... not sure. Loving this plugin, by the way. Thanks for all your work on it.
