### PR TITLE
Fix for issue #26

### DIFF
--- a/flexslider.css
+++ b/flexslider.css
@@ -17,7 +17,7 @@
 /* FlexSlider Necessary Styles
 *********************************/ 
 .flexslider {width: 100%; margin: 0; padding: 0;}
-.flexslider .slides > li {display: none;} /* Hide the slides before the JS is loaded. Avoids image jumping */
+.flexslider .slides > li {display: none; -webkit-backface-visibility: hidden;} /* Hide the slides before the JS is loaded. Avoids image jumping */
 .flexslider .slides img {max-width: 100%; display: block;}
 .flex-pauseplay span {text-transform: capitalize;}
 


### PR DESCRIPTION
Slide animation is causing flickering in Safari 5.1. Adding -webkit-backface-visibility: hidden; seems to fix it. Tested on OS X Lion and Safari 5.1.
