### PR TITLE
Swapping 'ontouchstart' for 'ontouchend'

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -25,7 +25,7 @@
       slider.currentSlide = slider.vars.slideToStart;
       slider.animatingTo = slider.currentSlide;
       slider.atEnd = (slider.currentSlide == 0) ? true : false;
-      slider.eventType = ('ontouchstart' in document.documentElement) ? 'touchstart' : 'click';
+      slider.eventType = ('ontouchend' in document.documentElement) ? 'touchend' : 'click';
       slider.cloneCount = 0;
       slider.cloneOffset = 0;
       slider.manualPause = false;


### PR DESCRIPTION
On sliders with large previous/next buttons it is impossible to scroll
up and down the page if the user accidentally touches the button area.
'ontouchend' waits for the touch to release thereby confirming the user
actually wants to 'click' the button rather than scroll…a minor change
but gets rid of the annoying problem of the user trying to avoid
touching a potentially large area on a small screen, when all they want to do is get up and
down the page
