### PR TITLE
Fixed an issue with the custom control container

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -42,6 +42,7 @@
 	slider.controlsContainer =  $(slider).find(slider.vars.controlsContainer);
         slider.containerExists = slider.controlsContainer.length > 0;
       }
+
       //Test for manualControls
       if (slider.vars.manualControls != "") {
         slider.manualControls = $(slider.vars.manualControls, ((slider.containerExists) ? slider.controlsContainer : slider));


### PR DESCRIPTION
I came across an issue where i was using two flexible carousels on a page and i had placed the custom controls container div outside of the '.slides' container. The plugin could not find this container because it looks for the index inside of the '.slides' container and my custom controls were not rendered. I've made a change which allows you to place the custom controls wherever you like inside of the container you are instantiating the plugin on and it will render the controls there.
