### PR TITLE
Fixes backwards compatibility with jQuery 1.3.2.

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -21,7 +21,7 @@
     slider.init = function() {
       slider.vars = $.extend({}, $.flexslider.defaults, options);
       $.data(el, 'flexsliderInit', true);
-	    slider.container = $('.slides', slider).first();
+	    slider.container = $('.slides', slider).eq(0);
 	    slider.slides = $('.slides:first > li', slider);
       slider.count = slider.slides.length;
       slider.animating = false;


### PR DESCRIPTION
Was getting the following error: "Object #<Object> has no method 'first'" because "first()" on line 24 is not supported in older jQuery versions. Needed this because Drupal 6 does not support jQuery higher than version 1.3.2
