### PR TITLE
Update jqueryflexslider.js

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -42,7 +42,7 @@
       
       //Test for controlsContainer
       if (slider.vars.controlsContainer != "") {
-        slider.controlsContainer = $(slider.vars.controlsContainer).eq($('.slides').index(slider.container));
+        slider.controlsContainer = $(slider.vars.controlsContainer).eq($('.slides', slider).index(slider.container));
         slider.containerExists = slider.controlsContainer.length > 0;
       }
       //Test for manualControls


### PR DESCRIPTION
Then we need more than one slider on the page with custom Controls, custom controls are only found for first slider. We need to pass 'slider' context to search in for controls container:
$('.slides', slider).index(slider.container)
