### PR TITLE
Use correct item in Thumbnail Slider Navigation

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -136,7 +136,7 @@
       },
       asNav: {
         setup: function() {
-          slider.currentItem = slider.currentSlide;
+          slider.currentItem = $(vars.asNavFor).data('flexslider').currentSlide;
           slider.slides.removeClass(namespace + "active-slide").eq(slider.currentItem).addClass(namespace + "active-slide");
           slider.slides.click(function(e){
             e.preventDefault();


### PR DESCRIPTION
To do with the slider-as-nav example: http://flex.madebymufffin.com/examples/thumbnail-slider.html

The asNav.setup nows sets the currentItem as the index of the current slide in the master slider, whereas before it would set currentItem to be the currentSlide the nav itself was on.

The reason I did this was when I was setting startAt to 2, meaning the 2nd slide in the master, the nav slider with 5 items a slide would show items 6-10, even though the 2nd slide in the nav slider had the active class. This fix solved the issue.
