### PR TITLE
Controls broken when using multiple sliders

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -61,9 +61,9 @@
           return false;
         }());
         // CONTROLSCONTAINER:
-        if (vars.controlsContainer !== "") slider.controlsContainer = $(vars.controlsContainer).length > 0 && $(vars.controlsContainer);
+        if (vars.controlsContainer !== "") slider.controlsContainer = $(vars.controlsContainer).length > 0 && $(vars.controlsContainer, slider);
         // MANUAL:
-        if (vars.manualControls !== "") slider.manualControls = $(vars.manualControls).length > 0 && $(vars.manualControls);
+        if (vars.manualControls !== "") slider.manualControls = $(vars.manualControls).length > 0 && $(vars.manualControls, slider);
         
         // RANDOMIZE:
         if (vars.randomize) {


### PR DESCRIPTION
With multiple sliders on the page, if you tried to use controlsContainer, it searched the entire page and built one large set of controls and attached it to both sliders causing them both to break.

I assume the same would have happened with manualControls so I also updated that scope, although admittedly I didn't verify that one. 
