### PR TITLE
[#284] BUGFIX: slider limit fixed to fully show last slide

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -693,7 +693,7 @@
         slider.pagingCount = Math.ceil(((slider.count - slider.visible)/slider.move) + 1);
         slider.last =  slider.pagingCount - 1;
         slider.limit = (slider.pagingCount === 1) ? 0 :
-                       (vars.itemWidth > slider.w) ? ((slider.itemW + (slideMargin * 2)) * slider.count) - slider.w - slideMargin : ((slider.itemW + slideMargin) * slider.count) - slider.w - slideMargin;
+                       (vars.itemWidth > slider.w) ? ((slider.itemW + (slideMargin * 2)) * slider.count) - slider.w - slideMargin : ((slider.itemW + slideMargin) * slider.count) - slider.w;
       } else {
         slider.itemW = slider.w;
         slider.pagingCount = slider.count;


### PR DESCRIPTION
Last slide was not been shown fully. The math to calculate slide.limit was wrong.
