### PR TITLE
initiating flexslider

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -875,7 +875,7 @@
         if ($slides.length === 1) {
           $slides.fadeIn(400);
           if (options.start) options.start($this);
-        } else if ($this.data('flexslider') === undefined) {
+        } else if ($this.data('flexslider') === undefined || $this.data('flexslider') === null) {
           new $.flexslider(this, options);
         }
       });


### PR DESCRIPTION
When running flexslider within wp, the flexslider object is not created. Narrowed it down to this line where the code checks for data('flexslider') and it looks like the object needs to be created when it is null as well.
