### PR TITLE
asNav: if active slide <= 0 to slider edge is clicked animate prev

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -143,7 +143,10 @@
             e.preventDefault();
             var $slide = $(this),
                 target = $slide.index();
-            if (!$(vars.asNavFor).data('flexslider').animating && !$slide.hasClass('active')) {
+            var posFromLeft = $slide.offset().left - $(slider).scrollLeft(); //Find position of slide relative to left of slider container
+            if(posFromLeft <= 0 && $slide.hasClass(namespace + 'active-slide')){
+              slider.flexAnimate(slider.getTarget("prev"), true);
+            } else if (!$(vars.asNavFor).data('flexslider').animating && !$slide.hasClass('active')) {
               slider.direction = (slider.currentItem < target) ? "next" : "prev";
               slider.flexAnimate(target, vars.pauseOnAction, false, true, true);
             }


### PR DESCRIPTION
If asNav and current active slide is <= 0 from slider edge and is clicked on will animate the carousel nav to prev position. Previously it often didn't do anything when active slide flush to edge or negative. Should fix issue #265: https://github.com/woothemes/FlexSlider/issues/265
