### PR TITLE
Fix for #401 - adding disabled to controlNav

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -23,6 +23,7 @@
         carousel = (vars.itemWidth > 0),
         fade = vars.animation === "fade",
         asNav = vars.asNavFor !== "",
+        disabledClass = namespace + 'disabled',
         methods = {};
     
     // Store a reference to the slider object
@@ -195,6 +196,7 @@
               event.preventDefault();
             });
           }
+          methods.controlNav.update();
         },
         setupManual: function() {
           slider.controlNav = slider.manualControls;
@@ -226,8 +228,10 @@
         },
         update: function(action, pos) {
           if (slider.pagingCount > 1 && action === "add") {
+            slider.controlNavScaffold.removeClass(disabledClass);
             slider.controlNavScaffold.append($('<li><a>' + slider.count + '</a></li>'));
           } else if (slider.pagingCount === 1) {
+            slider.controlNavScaffold.addClass(disabledClass);
             slider.controlNavScaffold.find('li').remove();
           } else {
             slider.controlNav.eq(pos).closest('li').remove();
@@ -264,7 +268,6 @@
           }
         },
         update: function() {
-          var disabledClass = namespace + 'disabled';
           if (slider.pagingCount === 1) {
             slider.directionNav.addClass(disabledClass);
           } else if (!vars.animationLoop) {


### PR DESCRIPTION
Moved disabled class up to the globals since it is now used in multiple
places
Adding/removing disabledClass to crontrolNavScaffold at appropriate
times
Needed to call controlNav.update during setup to apply the correct
class state. directionNav does the same thing (calling update within
the setup)
