### PR TITLE
Update flexslider.css

### DIFF
--- a/flexslider.css
+++ b/flexslider.css
@@ -27,7 +27,7 @@
 .flex-pauseplay span {text-transform: capitalize;}
 
 /* Clearfix for the .slides element */
-.slides:after {content: "."; display: block; clear: both; visibility: hidden; line-height: 0; height: 0;} 
+.slides:after {content: "\0020"; display: block; clear: both; visibility: hidden; line-height: 0; height: 0;} 
 html[xmlns] .slides {display: block;} 
 * html .slides {height: 1%;}
 


### PR DESCRIPTION
There is an issue with using content: "." on Android devices. They like to actually show the end point as opposed to hiding it. We can use the unicode space character to prevent this from happening.
