### PR TITLE
Set default opacity of disabled nav buttons to zero

### DIFF
--- a/flexslider.css
+++ b/flexslider.css
@@ -55,7 +55,7 @@ html[xmlns] .slides {display: block;}
 .flexslider:hover .flex-next {opacity: 0.8; right: 5px;}
 .flexslider:hover .flex-prev {opacity: 0.8; left: 5px;}
 .flexslider:hover .flex-next:hover, .flexslider:hover .flex-prev:hover {opacity: 1;}
-.flex-direction-nav .flex-disabled {opacity: .3!important; filter:alpha(opacity=30); cursor: default;}
+.flex-direction-nav .flex-disabled {opacity: 0!important; filter:alpha(opacity=00); cursor: default;}
 
 /* Control Nav */
 .flex-control-nav {width: 100%; position: absolute; bottom: -40px; text-align: center;}


### PR DESCRIPTION
## The Problem

I was having problems with the navigation buttons not hiding after sliding out of view, both on main slider images and on the carousel. I noticed that, in the CSS, disabled navigation items (i.e. the "previous" button on the first image) have an opacity of 30%, which didn't exactly make sense to me. 
## The Fix

I changed the opacity value to zero and the problem was remedied.
## Tested In
- Chrome 23.0.1271.64
- Firefox 16.0.2
- IE 9
