### PR TITLE
Update "active" class to namespace + "active-slide"

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -143,7 +143,7 @@
             e.preventDefault();
             var $slide = $(this),
                 target = $slide.index();
-            if (!$(vars.asNavFor).data('flexslider').animating && !$slide.hasClass('active')) {
+            if (!$(vars.asNavFor).data('flexslider').animating && !$slide.hasClass(namespace + "active-slide")) {
               slider.direction = (slider.currentItem < target) ? "next" : "prev";
               slider.flexAnimate(target, vars.pauseOnAction, false, true, true);
             }


### PR DESCRIPTION
A project I am working on uses the asNavFor with a carousel to act as navigation for another slider.  However I ran into a little problem.  When I clicked on the first or last items _twice_, all navigation would stop working (the carousel and the left/right arrows in the main viewport).  It seems the click callback was checking for an "active" class, which isn't on the slide ul > li's.  I've replaced the "active" class with namespace + "active-slide" which has fixed the problem for me.
