### PR TITLE
Fix flexslider when the orientation changes

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -125,7 +125,7 @@
         if (touch && vars.touch) methods.touch();
         
         // FADE&&SMOOTHHEIGHT || SLIDE:
-        if (!fade || (fade && vars.smoothHeight)) $(window).bind("resize focus", methods.resize);
+        if (!fade || (fade && vars.smoothHeight)) $(window).bind("resize orientationchange focus", methods.resize);
         
         
         // API: start() Callback


### PR DESCRIPTION
Note: you will also need to change the same thing in jquery.flexslider-min.js.

Problem:  When viewing Flexslider on an ipad the flexslider resizes on window resize but not on orientation change.  This patch fixes that.
