### PR TITLE
Pause slides when window loses focus - Prevents animation queue buildup

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -24,6 +24,7 @@
         fade = vars.animation === "fade",
         asNav = vars.asNavFor !== "",
         methods = {};
+        focused=true;
     
     // Store a reference to the slider object
     $.data(el, "flexslider", slider);
@@ -806,7 +807,13 @@
     
     //FlexSlider: Initialize
     methods.init();
-  }
+    
+    $(window).blur(function() {
+    focused = false;
+    }).focus(function() {
+        focused = true;
+      });
+    }
   
   //FlexSlider: Default Settings
   $.flexslider.defaults = {


### PR DESCRIPTION
Added a variable "focused=true;" at the top of the script and added a simple function to set and evaluate the variable on window focus and blur, in order to pause the slideshow if the user switches tabs or software.
Prevents the slides "building up" animation and blowing through a few slides all at once when you switch back to the window that is playing the slideshow.
