### PR TITLE
Fixed Documentation useCCS to useCSS

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -53,7 +53,7 @@ The markup structure for FlexSlider has been limited to a "ul.slide li" pattern 
 ### easing: *{new}*
 `easing` allows support for jQuery easing! Default options provided by jQuery are "swing" and "linear," but more can be used by included the jQuery Easing plugin. *If you chose a non-existent easing method, the slider will break.*
 
-*Note: You need to set `useCCS: false` to force transitions in browsers that support translate3d.*
+*Note: You need to set `useCSS: false` to force transitions in browsers that support translate3d.*
 *Optional: [jQuery Easing Plugin](http://gsgd.co.uk/sandbox/jquery/easing/)*
 
 ### direction: *{changed}*


### PR DESCRIPTION
Please find the following commit for the documentation markdown - this baffled me, as I couldn't find the reference to useCCS, before I realised that this should be useCSS
