### PR TITLE
Support for jQuery's .on with fallback to .live

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -200,7 +200,7 @@
           slider.controlNav = slider.manualControls;
           methods.controlNav.active();
 
-          slider.controlNav.live(eventType, function(event) {
+          var setupManualCallback = function(event) {
             event.preventDefault();
             var $this = $(this),
                 target = slider.controlNav.index($this);
@@ -209,12 +209,27 @@
               (target > slider.currentSlide) ? slider.direction = "next" : slider.direction = "prev";
               slider.flexAnimate(target, vars.pauseOnAction);
             }
-          });
-          // Prevent iOS click event bug
-          if (touch) {
-            slider.controlNav.live("click touchstart", function(event) {
-              event.preventDefault();
-            });
+          };
+
+          // detect if 'on' method is supported
+          if(slider.controlNav.on)
+          {
+            slider.controlNav.on(eventType, setupManualCallback);
+            // Prevent iOS click event bug
+            if (touch) {
+              slider.controlNav.on("click touchstart", function(event) {
+                event.preventDefault();
+              });
+            }
+          }
+          else
+          {
+            slider.controlNav.live(eventType, setupManualCallback);
+            if (touch) {
+              slider.controlNav.live("click touchstart", function(event) {
+                event.preventDefault();
+              });
+            }
           }
         },
         set: function() {


### PR DESCRIPTION
jQuery versions >=1.9.x have dropped support for .live method, therefore .on has to be used.

In order FlexSlider to have support for older versions of jQuery (that doesn't have .on) fallback .live will be used.
