### PR TITLE
Make sure currentSlide is a number

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -35,7 +35,9 @@
     methods = {
       init: function() {
         slider.animating = false;
-        slider.currentSlide = slider.vars.startAt;
+        // Get current slide and make sure it is a number
+        slider.currentSlide = parseInt( ( slider.vars.startAt ? slider.vars.startAt : 0) );
+        if ( isNaN( slider.currentSlide ) ) slider.currentSlide = 0;
         slider.animatingTo = slider.currentSlide;
         slider.atEnd = (slider.currentSlide === 0 || slider.currentSlide === slider.last);
         slider.containerSelector = slider.vars.selector.substr(0,slider.vars.selector.search(' '));


### PR DESCRIPTION
Make sure that currentSlide is a number and not a string. If it is a
string like '1', FlexSlider will start appending instead of doing the
correct calculations.
