### PR TITLE
Thumbnails controlNav update

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -167,8 +167,8 @@
 
           if (slider.pagingCount > 1) {
             for (var i = 0; i < slider.pagingCount; i++) {
-              item = (vars.controlNav === "thumbnails") ? '<img src="' + slider.slides.eq(i).attr("data-thumb") + '"/>' : '<a>' + j + '</a>';
-              slider.controlNavScaffold.append('<li><a href="#">' + item + '</a></li>');
+              item = (vars.controlNav === "thumbnails") ? '<a href="#"><img src="' + slider.slides.eq(i).attr("data-thumb") + '"/></a>' : '<a>' + j + '</a>';
+              slider.controlNavScaffold.append('<li>' + item + '</li>');
               j++;
             }
           }


### PR DESCRIPTION
When controlNav has been set to 'thumbnails' until now, for no 
reason the images in the nav has been used as selectors, so I've wrapped
them into a link. This is better, because You now can inject some hover
into the thumbnails control nav  without breaking it.

See http://demo.dotwired.de/necon/ and hover the thumbnails to see what I mean by "breaking" it. As soon as you hover the "View" circle, You cannot change the slide any more.

PS.: I've set the li as a new .flex-active selector, you may have other thoughts about this.
