### PR TITLE
Added an init callback

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -690,6 +690,9 @@
       // !CAROUSEL:
       // CANDIDATE: active slide
       if (!carousel) slider.slides.removeClass(namespace + "active-slide").eq(slider.currentSlide).addClass(namespace + "active-slide");
+	  
+      //FlexSlider: init() Callback
+      vars.init(slider);
     }
 
     slider.doMath = function() {
@@ -866,7 +869,8 @@
     after: function(){},            //Callback: function(slider) - Fires after each slider animation completes
     end: function(){},              //Callback: function(slider) - Fires when the slider reaches the last slide (asynchronous)
     added: function(){},            //{NEW} Callback: function(slider) - Fires after a slide is added
-    removed: function(){}           //{NEW} Callback: function(slider) - Fires after a slide is removed
+    removed: function(){},          //{NEW} Callback: function(slider) - Fires after a slide is removed
+    init: function() {}             //{NEW} Callback: function(slider) - Fires after the slider is initially setup
   }
 
 


### PR DESCRIPTION
This callback fires before the "start" callback and allows for modification of the slider before it's fully visible. For example, I find the sudden display of the slider a bit jarring, so I'm using the new callback to hide the slider in "init", and then `.slideDown()` in "start".
