### PR TITLE
changed execution order of the before callback

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -536,11 +536,12 @@
 
         slider.animating = true;
         slider.animatingTo = target;
-        // API: before() animation Callback
-        slider.vars.before(slider);
 
         // SLIDESHOW:
         if (pause) slider.pause();
+
+        // API: before() animation Callback
+        slider.vars.before(slider);
 
         // SYNC:
         if (slider.syncExists && !fromNav) methods.sync("animate");


### PR DESCRIPTION
With this fix the pause function is able to correctly set its flag (playing) and therefore the before callback gets the correct slider object.
