### PR TITLE
prevent messing with slider.direction when going from last to first and ...

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -509,7 +509,7 @@
 
     // public methods
     slider.flexAnimate = function(target, pause, override, withSync, fromNav) {
-      if (target !== slider.currentSlide) {
+      if (!slider.vars.animationLoop && target !== slider.currentSlide) {
         slider.direction = (target > slider.currentSlide) ? "next" : "prev";
       }
 


### PR DESCRIPTION
...when var.animationLoop is true. The first conditional check inside slider.flexAnimate should't fun if slider.vars.animationLoop is true; the but in issue 284 that was resolved by this check was only a bug in the slider.vars.animationLoop===false scenario. 
