### PR TITLE
Fixed slider.play() leaving unstoppable setIntervals.

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -567,6 +567,7 @@
     }
     // SLIDESHOW:
     slider.play = function() {
+      if (slider.playing) clearInterval(slider.animatedSlides);
       slider.animatedSlides = setInterval(slider.animateSlides, vars.slideshowSpeed);
       slider.playing = true;
       // PAUSEPLAY:


### PR DESCRIPTION
If you call slider.play() more than once in a row, previous intervals are not cleared. Reference is lost to them, so they can never be stopped again and stack up. The fix calls clearInterval first if the slider is already playing.
