### PR TITLE
Use viewport (instead of slider) width for calculations

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -787,7 +787,7 @@
           minItems = slider.vars.minItems,
           maxItems = slider.vars.maxItems;
 
-      slider.w = slider.width();
+      slider.w = (slider.viewport===undefined) ? slider.width() : slider.viewport.width();
       slider.h = slide.height();
       slider.boxPadding = slide.outerWidth() - slide.width();
 


### PR DESCRIPTION
Fix allows to style viewport to be smaller than the slider (for ex. for
keeping direction nav beside slides) and keep the carousel
functionality. Prevents skipping slides...
