### PR TITLE
make FlexSlider (more) accessible to screen readers

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -216,8 +216,8 @@
               ctlId = slideId + '-ctl';
               slide.attr('id', slideId).attr('aria-labelledby', ctlId);
               item = (slider.vars.controlNav === "thumbnails")
-                   ? '<img src="../' + slide.attr( 'data-thumb' ) + '" id="' + ctlId + '" role="tab" aria-controls="' + slideId + '"/>'
-                   : '<a id="' + ctlId + '" role="tab" aria-controls="' + slideId + '">' + j + '</a>';
+                   ? '<img src="../' + slide.attr( 'data-thumb' ) + '" id="' + ctlId + '" role="tab" aria-controls="' + slideId + '" href="#"/>'
+                   : '<a id="' + ctlId + '" role="tab" aria-controls="' + slideId + '" href="#">' + j + '</a>';
               if ( 'thumbnails' === slider.vars.controlNav && true === slider.vars.thumbCaptions ) {
                 var captn = slide.attr( 'data-thumbcaption' );
                 if ( '' != captn && undefined != captn ) item += '<span class="' + namespace + 'caption">' + captn + '</span>';


### PR DESCRIPTION
I've made some modifications to FlexSlider to make it (more) accessible to users who use screen readers and / or use the keyboard to navigate. I think it would benefit the community at large if you would integrate these modifications into the code base.

Notes on the code: To properly set the control's aria-controls attribute, the slides need to have a unique id attribute. Where the id attribute is already present, I use it. Where it is not present I generate one. To handle the case where there are multiple sliders on a page I use / generate a unique id for each slider, then use that to generate id's for the slides. Note that when flexslider() is called multiple times on a page on elements which do not already have id's, the generated id's may not be unique. However I feel this is a relatively rare case, and there's an easy workaround - specify unique id's for each slider, so I feel it's acceptable behavior.

Thanks for your consideration.
