### PR TITLE
Fix no/before js load issue when using custom selector

### DIFF
--- a/flexslider.css
+++ b/flexslider.css
@@ -37,7 +37,7 @@
 /* FlexSlider Necessary Styles
 *********************************/
 .flexslider {margin: 0; padding: 0;}
-.flexslider .slides > li {display: none; -webkit-backface-visibility: hidden;} /* Hide the slides before the JS is loaded. Avoids image jumping */
+.flexslider .slides > * {display: none; -webkit-backface-visibility: hidden;} /* Hide the slides before the JS is loaded. Avoids image jumping */
 .flexslider .slides img {width: 100%; display: block;}
 .flex-pauseplay span {text-transform: capitalize;}
 
@@ -47,9 +47,7 @@ html[xmlns] .slides {display: block;}
 * html .slides {height: 1%;}
 
 /* No JavaScript Fallback */
-/* If you are not using another script, such as Modernizr, make sure you
- * include js that eliminates this class on page load */
-.no-js .slides > li:first-child {display: block;}
+.slides > *:first-child {display: block;}
 
 /* FlexSlider Default Theme
 *********************************/


### PR DESCRIPTION
Changed '.slides > li' to '.slides > *' to prevent showing all slides before JS loads (or if it doesn't) when using custom selectors like {selector: ".slides > div"}.

Also removed .no-js from JS fallback to enable for users who don't have .no-js on body. No negative consequences as flexslider's inline styles overrule it. Also allows first slide to show if script file or plugin JS fails to load/run.
