### PR TITLE
Flexslider.css Firefox negative margin bug

### DIFF
--- a/flexslider.css
+++ b/flexslider.css
@@ -42,7 +42,7 @@
 .flex-pauseplay span {text-transform: capitalize;}
 
 /* Clearfix for the .slides element */
-.slides:after {content: "\0020"; display: block; clear: both; visibility: hidden; line-height: 0; height: 0;}
+.slides:after {content: "."; display: block; clear: both; visibility: hidden; line-height: 0; height: 0;}
 html[xmlns] .slides {display: block;}
 * html .slides {height: 1%;}
 


### PR DESCRIPTION
In the latest Firefox if you're using negative margins on '.flexslider', plus a positive bottom margin it cause  flexslider to move down by whatever value is giving on the bottom margin. Changing the content value to a period fixes this and causes no harm to other browsers.
