### PR TITLE
Tap gesture issue on ios/android devices

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -465,6 +465,7 @@
               startY = null;
               dx = null;
               offset = null;
+              slider.animating = false;
             }
         }else{
             el.style.msTouchAction = "none";


### PR DESCRIPTION
I've had an issue with a tap gesture on mobile devices (android and iOS). The gesture doesn't trigger the slider to show next items. The slider even doesn't work with others gestures after the first try to make a tap.

After some research I've found that the Slider was locked into the event.preventDefault part in onTouchStart-Listener, because slider.animating was set to true, but there was no running animation.  

``` javascript
function onTouchStart(e) {
  if (slider.animating) {
    e.preventDefault();
  } else if ( ( window.navigator.msPointerEnabled ) || e.touches.length === 1 ) {
  .....
  }
}
```

So I've forced in the onTouchEnd-Listener to set slider.animating to false and it solves the problem. I don't know if this is an enhancement in general.The behaviour of the slider didn't broke with this solution.
