### PR TITLE
Fix "onTouchStart is not defined" in FF Android

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -395,7 +395,6 @@
           accDx = 0;
 
         if(!msGesture){
-            el.addEventListener('touchstart', onTouchStart, false);
 
             function onTouchStart(e) {
               if (slider.animating) {
@@ -423,6 +422,8 @@
                 el.addEventListener('touchend', onTouchEnd, false);
               }
             }
+            
+            el.addEventListener('touchstart', onTouchStart, false);
 
             function onTouchMove(e) {
               // Local vars for X and Y points.


### PR DESCRIPTION
Firefox for Android will fire a "onTouchStart is not defined" error. moving the eventListener down after the function will solve the problem.
