### PR TITLE
Fix Event Handler for Added Thumb Slides

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -158,7 +158,7 @@
           slider.currentItem = slider.currentSlide;
           slider.slides.removeClass(namespace + "active-slide").eq(slider.currentItem).addClass(namespace + "active-slide");
           if(!msGesture){
-              slider.slides.on(eventType, function(e){
+              slider.on(eventType, slider.vars.selector, function(e){
                 e.preventDefault();
                 var $slide = $(this),
                     target = $slide.index();


### PR DESCRIPTION
The click handler was being bound on each slide and when a slide is added,
it wasn't being attached to new slides. Uses event bubbling instead so
there is only one handler on the parent slider and we don't have to
remember to attach the handle when a slide is added.
