### PR TITLE
use width() to account for paddings

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -903,7 +903,7 @@
           slider.setProps(sliderOffset * slider.computedW, "init");
           setTimeout(function(){
             slider.doMath();
-            slider.newSlides.css({"width": slider.computedW, "float": "left", "display": "block"});
+            slider.newSlides.width(slider.computedW).css({"float": "left", "display": "block"});
             // SMOOTH HEIGHT:
             if (slider.vars.smoothHeight) methods.smoothHeight();
           }, (type === "init") ? 100 : 0);

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -556,7 +556,7 @@
       },
       resize: function() {
         if (!slider.animating && slider.is(':visible')) {
-          if (!carousel) slider.doMath();
+          slider.doMath();
 
           if (fade) {
             // SMOOTH HEIGHT:


### PR DESCRIPTION
On initialisation the width of my slides missed the padding.
When I focussed or resized the window the sizes jumped back to normal.
It appears that $.css({width:'100px'}); doesn't account for paddings while $.width('100px') does.
Or in other words, the first method sets the outerwidth while the latter sets the innerwidth.

Secondly, in case of using the minItems and maxItems the pagingCount is wrong sometimes.
When the window is small and the carousel moved to the last page, then resize the window to full size.
The carousel will go blank because it tries to open the same page while it doesn't have that amount of pages anymore. So slider.doMath(); should be called when the slider is a carousel.
