### PR TITLE
Less: Small fixes & improvements (box-shadow & font)

### DIFF
--- a/css/font.less
+++ b/css/font.less
@@ -3,15 +3,19 @@
  * ====================================================================================================================*/
 
 
-@font-face {
+& when  (@font = true) {
 
-  font-family: '@{font-name}';
-  src:url('@{font-path}/@{font-file-name}.eot');
-  src:url('@{font-path}/@{font-file-name}.eot?#iefix') format('embedded-opentype'),
-    url('@{font-path}/@{font-file-name}.woff') format('woff'),
-    url('@{font-path}/@{font-file-name}.ttf') format('truetype'),
-    url('@{font-path}/@{font-file-name}.svg#flexslider-icon') format('svg');
-  font-weight: normal;
-  font-style: normal;
+	@font-face {
+
+	  font-family: '@{font-name}';
+	  src:url('@{font-path}/@{font-file-name}.eot');
+	  src:url('@{font-path}/@{font-file-name}.eot?#iefix') format('embedded-opentype'),
+		url('@{font-path}/@{font-file-name}.woff') format('woff'),
+		url('@{font-path}/@{font-file-name}.ttf') format('truetype'),
+		url('@{font-path}/@{font-file-name}.svg#flexslider-icon') format('svg');
+	  font-weight: normal;
+	  font-style: normal;
+
+	}
 
 }

--- a/css/font.less
+++ b/css/font.less
@@ -12,7 +12,7 @@
 	  src:url('@{font-path}/@{font-file-name}.eot?#iefix') format('embedded-opentype'),
 		url('@{font-path}/@{font-file-name}.woff') format('woff'),
 		url('@{font-path}/@{font-file-name}.ttf') format('truetype'),
-		url('@{font-path}/@{font-file-name}.svg#flexslider-icon') format('svg');
+		url('@{font-path}/@{font-file-name}.svg#@{font-svg-id}') format('svg');
 	  font-weight: normal;
 	  font-style: normal;
 

--- a/css/variables.less
+++ b/css/variables.less
@@ -8,7 +8,7 @@
 @default-box-shadow-y-axis:           1px;
 @default-box-shadow-blur:             2px;
 @default-box-shadow-color:            rgba( 0, 0, 0, 0.2 );
-@default-box-shadow-inset:            '';
+@default-box-shadow-inset:            ~'';
 @flexslider-margin:                   0 0 60px;
 @flexslider-bg:                       #fff;
 @flexslider-border:                   4px solid #fff;
@@ -17,7 +17,7 @@
 @flexslider-box-shadow-y-axis:        1px;
 @flexslider-box-shadow-blur:          4px;
 @flexslider-box-shadow-color:         rgba( 0, 0, 0, 0.2 );
-@flexslider-box-shadow-inset:         '';
+@flexslider-box-shadow-inset:         ~'';
 @flex-viewport-max-height:            2000px;
 @flex-viewport-loading-max-height:    300px;
 @flex-control-thumbs:                 5px 0 0;

--- a/css/variables.less
+++ b/css/variables.less
@@ -2,6 +2,7 @@
 @font-path:                           "fonts";
 @font-name:                           "flexslider-icon";
 @font-file-name:                      "flexslider-icon";
+@font-svg-id:                         "flexslider-icon";
 @default-duration:                    1s;
 @default-easing:                      ease;
 @default-border-radius:               5px;
@@ -9,7 +10,7 @@
 @default-box-shadow-y-axis:           1px;
 @default-box-shadow-blur:             2px;
 @default-box-shadow-color:            rgba( 0, 0, 0, 0.2 );
-@default-box-shadow-inset:            ~'';
+@default-box-shadow-inset:            ~"";
 @flexslider-margin:                   0 0 60px;
 @flexslider-bg:                       #fff;
 @flexslider-border:                   4px solid #fff;
@@ -18,7 +19,7 @@
 @flexslider-box-shadow-y-axis:        1px;
 @flexslider-box-shadow-blur:          4px;
 @flexslider-box-shadow-color:         rgba( 0, 0, 0, 0.2 );
-@flexslider-box-shadow-inset:         ~'';
+@flexslider-box-shadow-inset:         ~"";
 @flex-viewport-max-height:            2000px;
 @flex-viewport-loading-max-height:    300px;
 @flex-control-thumbs:                 5px 0 0;
@@ -26,7 +27,7 @@
 @flex-direction-nav-text-shadow:      1px 1px 0 rgba( 255, 255, 255, 0.3 );
 @flex-direction-nav-icon-color:       rgba(0,0,0,0.8);
 @flex-direction-nav-icon-text-shadow: 1px 1px 0 rgba( 255, 255, 255, 0.3 );
-@flex-direction-nav-icon-prev:        '\f001';
-@flex-direction-nav-icon-next:        '\f002';
-@flex-pauseplay-icon-play:            '\f003';
-@flex-pauseplay-icon-pause:           '\f004';
+@flex-direction-nav-icon-prev:        "\f001";
+@flex-direction-nav-icon-next:        "\f002";
+@flex-pauseplay-icon-play:            "\f003";
+@flex-pauseplay-icon-pause:           "\f004";

--- a/css/variables.less
+++ b/css/variables.less
@@ -1,3 +1,4 @@
+@font:                                true;
 @font-path:                           "fonts";
 @font-name:                           "flexslider-icon";
 @font-file-name:                      "flexslider-icon";


### PR DESCRIPTION
## Fix: box-shadow

You should use `~""` instead of just `""`, otherwise you get
following result after comiling:
`box-shadow: "" 0 1px 2px rgba( 0, 0, 0, 0.2 );`
## Improvement:  Added possibility to disable the font-face

So it's possible to use custom font icons without loading the
flexslider font icons (for better performance / less files to load on
client side)

Here's an example with FontAwesome:

```
@font:                           false;
@font-name:                      "FontAwesome";
@flex-direction-nav-icon-prev:   "\f053";
@flex-direction-nav-icon-next:   "\f054";
@flex-pauseplay-icon-play:       "\f04b";
@flex-pauseplay-icon-pause:      "\f04c";
```
