### PR TITLE
Fixes #679 - reset global properties.

### DIFF
--- a/css/theme.less
+++ b/css/theme.less
@@ -61,6 +61,8 @@
 
     text-decoration: none; 
     display: block; 
+    line-height: 1; 
+    border: none; 
     width: 40px; 
     height: 40px; 
     margin: -20px 0 0; 
@@ -74,6 +76,12 @@
     text-shadow: @flex-direction-nav-text-shadow;
 
     .transition( 0.3s, ease-in-out );
+
+    &:hover  { 
+
+      border: none; 
+ 
+    }
 
     &:before  { 
 


### PR DESCRIPTION
Resets properties on the navigational links to prevent the icon from getting cutoff.
