### PR TITLE
Add LESS variable for hover state on nav-icon (:before) for better bower use

### DIFF
--- a/css/theme.less
+++ b/css/theme.less
@@ -91,6 +91,16 @@
       content: @flex-direction-nav-icon-next;
 
     }
+    
+    &:hover {
+
+      &:before {
+
+        color: @flex-direction-nav-icon-hover-color;
+
+      }
+
+    }
 
   }
 

--- a/css/variables.less
+++ b/css/variables.less
@@ -24,6 +24,7 @@
 @flex-direction-nav-color:            rgba(0,0,0,0.8);
 @flex-direction-nav-text-shadow:      1px 1px 0 rgba( 255, 255, 255, 0.3 );
 @flex-direction-nav-icon-color:       rgba(0,0,0,0.8);
+@flex-direction-nav-icon-hover-color: rgba(0,0,0,1);
 @flex-direction-nav-icon-text-shadow: 1px 1px 0 rgba( 255, 255, 255, 0.3 );
 @flex-direction-nav-icon-prev:        '\f001';
 @flex-direction-nav-icon-next:        '\f002';


### PR DESCRIPTION
I was customizing my nav arrows today and came across that I can set my icon color, but cannot set the hover color with a variable. I am using bower so I'm not modifying core code there, just setting / overwriting the less variables
