### PR TITLE
Resolves #811, #867 fixing animationLoop:false

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -841,9 +841,13 @@
     slider.getTarget = function(dir) {
       slider.direction = dir;
       if (dir === "next") {
-        return (slider.currentSlide === slider.last) ? 0 : slider.currentSlide + 1;
+        return (slider.currentSlide !== slider.last) ? slider.currentSlide + 1 :
+               (slider.vars.animationLoop) ? 0 :
+               slider.currentSlide;
       } else {
-        return (slider.currentSlide === 0) ? slider.last : slider.currentSlide - 1;
+        return (slider.currentSlide !== 0) ? slider.currentSlide - 1 :
+               (slider.vars.animationLoop) ? slider.last :
+               slider.currentSlide;
       }
     };
 


### PR DESCRIPTION
Issues #811 & #867 were recently closed (as part of your housekeeping), but the issue not actually fixed. This PR ensures that FlexSlider respects the optional setting of `animationLoop:false`.
