### PR TITLE
Adding option not to fade the previous slide out during transition (#1308)

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -770,11 +770,11 @@
             //slider.slides.eq(target).fadeIn(slider.vars.animationSpeed, slider.vars.easing, slider.wrapup);
 
             if (slider.vars.fadeOutDuringTransition == false) {
-				slider.slides.eq(slider.currentSlide).css({"zIndex": 1});
-			} else {
-				slider.slides.eq(slider.currentSlide).css({"zIndex": 1}).animate({"opacity": 0}, slider.vars.animationSpeed, slider.vars.easing);
-			}
-			slider.slides.eq(target).css({"zIndex": 2}).animate({"opacity": 1}, slider.vars.animationSpeed, slider.vars.easing, slider.wrapup);
+              slider.slides.eq(slider.currentSlide).css({"zIndex": 1});
+            } else {
+              slider.slides.eq(slider.currentSlide).css({"zIndex": 1}).animate({"opacity": 0}, slider.vars.animationSpeed, slider.vars.easing);
+            }
+            slider.slides.eq(target).css({"zIndex": 2}).animate({"opacity": 1}, slider.vars.animationSpeed, slider.vars.easing, slider.wrapup);
 
           } else {
             slider.slides.eq(slider.currentSlide).css({ "opacity": 0, "zIndex": 1 });
@@ -788,9 +788,9 @@
     };
     slider.wrapup = function(dimension) {
       // SLIDE:
-	  if (slider.vars.fadeOutDuringTransition == false) {
-		slider.slides.eq(slider.currentSlide).css({"opacity": 0});
-	  }
+      if (slider.vars.fadeOutDuringTransition == false) {
+        slider.slides.eq(slider.currentSlide).css({"opacity": 0});
+      }
       if (!fade && !carousel) {
         if (slider.currentSlide === 0 && slider.animatingTo === slider.last && slider.vars.animationLoop) {
           slider.setProps(dimension, "jumpEnd");

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -769,8 +769,12 @@
             //slider.slides.eq(slider.currentSlide).fadeOut(slider.vars.animationSpeed, slider.vars.easing);
             //slider.slides.eq(target).fadeIn(slider.vars.animationSpeed, slider.vars.easing, slider.wrapup);
 
-            slider.slides.eq(slider.currentSlide).css({"zIndex": 1}).animate({"opacity": 0}, slider.vars.animationSpeed, slider.vars.easing);
-            slider.slides.eq(target).css({"zIndex": 2}).animate({"opacity": 1}, slider.vars.animationSpeed, slider.vars.easing, slider.wrapup);
+            if (slider.vars.fadeOutDuringTransition == false) {
+				slider.slides.eq(slider.currentSlide).css({"zIndex": 1});
+			} else {
+				slider.slides.eq(slider.currentSlide).css({"zIndex": 1}).animate({"opacity": 0}, slider.vars.animationSpeed, slider.vars.easing);
+			}
+			slider.slides.eq(target).css({"zIndex": 2}).animate({"opacity": 1}, slider.vars.animationSpeed, slider.vars.easing, slider.wrapup);
 
           } else {
             slider.slides.eq(slider.currentSlide).css({ "opacity": 0, "zIndex": 1 });
@@ -784,6 +788,9 @@
     };
     slider.wrapup = function(dimension) {
       // SLIDE:
+	  if (slider.vars.fadeOutDuringTransition == false) {
+		slider.slides.eq(slider.currentSlide).css({"opacity": 0});
+	  }
       if (!fade && !carousel) {
         if (slider.currentSlide === 0 && slider.animatingTo === slider.last && slider.vars.animationLoop) {
           slider.setProps(dimension, "jumpEnd");
@@ -1099,6 +1106,7 @@
     initDelay: 0,                   //{NEW} Integer: Set an initialization delay, in milliseconds
     randomize: false,               //Boolean: Randomize slide order
     fadeFirstSlide: true,           //Boolean: Fade in the first slide when animation type is "fade"
+    fadeOutDuringTransition: true,  //Boolean: Whether previous slide should fade out while next slide fades in
     thumbCaptions: false,           //Boolean: Whether or not to put captions on thumbnails when using the "thumbnails" controlNav.
 
     // Usability features


### PR DESCRIPTION
Adding option not to fade the previous slide out during transition; instead, previous slides becomes opacity:0 after next slide has fully faded in.
