### PR TITLE
Second asNav slide fix

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -831,7 +831,7 @@
       var last = (asNav) ? slider.pagingCount - 1 : slider.last;
       return (fromNav) ? true :
              (asNav && slider.currentItem === slider.count - 1 && target === 0 && slider.direction === "prev") ? true :
-             (asNav && slider.currentItem === 0 && target === slider.pagingCount - 1 && slider.direction !== "next") ? false :
+             (asNav && slider.currentItem === 0 && fade && target === slider.pagingCount - 1 && slider.direction !== "next") ? false :
              (target === slider.currentSlide && !asNav) ? false :
              (slider.vars.animationLoop) ? true :
              (slider.atEnd && slider.currentSlide === 0 && target === last && slider.direction !== "next") ? false :


### PR DESCRIPTION
I _believe_ I've solved this issue where the second slide of an 'asNav' slider wouldn't move to its second slide when advancing the master slider. The `target === slider.pagingCount - 1` conditional initially returns `true` for carousel-style sliders when it should return `false`.
