### PR TITLE
Properly advance synced slider when move ≠ visible (#1316)

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -677,15 +677,15 @@
           slider.direction = (slider.currentItem < target) ? "next" : "prev";
           master.direction = slider.direction;
 
-          if (Math.ceil((target + 1)/slider.visible) - 1 !== slider.currentSlide && target !== 0) {
-            slider.currentItem = target;
-            slider.slides.removeClass(namespace + "active-slide").eq(target).addClass(namespace + "active-slide");
-            target = Math.floor(target/slider.visible);
-          } else {
-            slider.currentItem = target;
-            slider.slides.removeClass(namespace + "active-slide").eq(target).addClass(namespace + "active-slide");
-            return false;
-          }
+          slider.currentItem = target;
+          slider.slides.removeClass(namespace + "active-slide").eq(target).addClass(namespace + "active-slide");
+
+          // Subtract the sum of the visible number of slides and (the product
+          // of the current slide number and the slides per move); subtract from
+          // one greater than the target slide number of the master slider; and
+          // make sure the result isn't negative. This is the target slide of
+          // the nav slider.
+          target = Math.max(0, (target + 1) - slider.visible + slider.move * slider.currentSlide);
         }
 
         slider.animating = true;

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -680,11 +680,10 @@
           slider.currentItem = target;
           slider.slides.removeClass(namespace + "active-slide").eq(target).addClass(namespace + "active-slide");
 
-          // Subtract the sum of the visible number of slides and (the product
-          // of the current slide number and the slides per move); subtract from
-          // one greater than the target slide number of the master slider; and
-          // make sure the result isn't negative. This is the target slide of
-          // the nav slider.
+          // Calculate the "real" target slide index to animate to
+          //
+          // For sliders with differing 'move' and 'visible' values, this
+          // requires some math.
           target = Math.max(0, Math.floor((target - slider.visible) / slider.move) + 1);
         }
 

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -685,7 +685,7 @@
           // one greater than the target slide number of the master slider; and
           // make sure the result isn't negative. This is the target slide of
           // the nav slider.
-          target = Math.max(0, (target + 1) - slider.visible + slider.move * slider.currentSlide);
+          target = Math.max(0, Math.floor((target - slider.visible) / slider.move) + 1);
         }
 
         slider.animating = true;


### PR DESCRIPTION
Two of the three things that happened within these two conditional blocks weren't dependent on the outcome of the conditional at all.

Also some faulty math in setting a new target value could mess up a synced carousel slider.
