### PR TITLE
Allow synced slider to move to first slide after reaching end on master slider (#1318)

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -677,7 +677,7 @@
           slider.direction = (slider.currentItem < target) ? "next" : "prev";
           master.direction = slider.direction;
 
-          if (Math.ceil((target + 1)/slider.visible) - 1 !== slider.currentSlide && target !== 0) {
+          if (Math.ceil((target + 1)/slider.visible) - 1 !== slider.currentSlide) {
             slider.currentItem = target;
             slider.slides.removeClass(namespace + "active-slide").eq(target).addClass(namespace + "active-slide");
             target = Math.floor(target/slider.visible);


### PR DESCRIPTION
Unnecessarily asks if target = 0, when this should work just fine (with the proper math).

May conflict with Pull Request #1317 which includes the same change in a different commit (my mistake).
