### PR TITLE
Add Flexslider setting to show controlnav even for a single slide

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -214,7 +214,13 @@
 
           slider.controlNavScaffold = $('<ol class="'+ namespace + 'control-nav ' + namespace + type + '"></ol>');
 
-          if (slider.pagingCount > 1) {
+          // set limiter to 1 as original default or set to 0 if setting is true
+          var controlNavLimiter = 1;
+          if(slider.vars.controlNavSingle) {
+            controlNavLimiter = 0;
+          }
+
+          if (slider.pagingCount > controlNavLimiter) {
             for (var i = 0; i < slider.pagingCount; i++) {
               slide = slider.slides.eq(i);
               item = (slider.vars.controlNav === "thumbnails") ? '<img src="' + slide.attr( 'data-thumb' ) + '"/>' : '<a>' + j + '</a>';
@@ -1120,6 +1126,7 @@
 
     // Primary Controls
     controlNav: true,               //Boolean: Create navigation for paging control of each slide? Note: Leave true for manualControls usage
+    controlNavSingle: false,         //Boolean: Create navigation for paging control even with single slide? Note: Leave false for default controlNav behavior
     directionNav: true,             //Boolean: Create navigation for previous/next navigation? (true/false)
     prevText: "Previous",           //String: Set the text for the "previous" directionNav item
     nextText: "Next",               //String: Set the text for the "next" directionNav item


### PR DESCRIPTION
Allow the controlNav (thumbnails) to be shown when there is only 1 slide. This still defaults to original behavior but switching to true will enable this.
