### PR TITLE
Resolves issue 1412

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -128,7 +128,13 @@
             slider.hover(function() {
               if (!slider.manualPlay && !slider.manualPause) { slider.pause(); }
             }, function() {
-              if (!slider.manualPause && !slider.manualPlay && !slider.stopped) { slider.play(); }
+              if (!slider.manualPause && !slider.manualPlay && !slider.stopped) {
+                var lastSlide = slider.currentSlide === slider.last;
+                // If we are on the last slide and animationLoop is deactivated do not resume slideshow.
+                if (!(lastSlide && !slider.animationLoop)) {
+                  slider.play();
+                }
+              }
             });
           }
           // initialize animation


### PR DESCRIPTION
#### Issue

Resolves issue outlined here:
https://github.com/woothemes/FlexSlider/issues/1412
#### Summary

When using a slider with the following parameters:

```
    animation: "slide",
    animationLoop: false,
    pauseOnHover: true,
    slideshow: true,
```

the slideshow should stop on the last slide (because `animationLoop` is set to `false`). However, when the user hovers over the last slide, and then moves the mouse away, the slideshow returns to the first slide. This is because the function related to the `pauseOnHover` parameter which resumes the slideshow, does not consider the `animationLoop` parameter. 

This PR resolves this bug.
