### PR TITLE
Disable nav items on deactivation (do not only use opacity, still hoverable)

### DIFF
--- a/css/theme.less
+++ b/css/theme.less
@@ -69,6 +69,7 @@
     top: 50%;
     z-index: 10;
     overflow: hidden;
+    visibility: hidden;
     opacity: 0;
     cursor: pointer;
     color: @flex-direction-nav-color;
@@ -127,6 +128,7 @@
 
     .flex-prev {
 
+      visibility: visible;
       opacity: 0.7;
       left: 10px;
 
@@ -140,6 +142,7 @@
 
     .flex-next {
 
+      visibility: visible;
       opacity: 0.7;
       right: 10px;
 

--- a/flexslider.css
+++ b/flexslider.css
@@ -120,6 +120,7 @@ html[xmlns] .flexslider .slides {
   top: 50%;
   z-index: 10;
   overflow: hidden;
+  visibility: hidden;
   opacity: 0;
   cursor: pointer;
   color: rgba(0, 0, 0, 0.8);
@@ -149,6 +150,7 @@ html[xmlns] .flexslider .slides {
   text-align: right;
 }
 .flexslider:hover .flex-direction-nav .flex-prev {
+  visibility: visible;
   opacity: 0.7;
   left: 10px;
 }
@@ -156,6 +158,7 @@ html[xmlns] .flexslider .slides {
   opacity: 1;
 }
 .flexslider:hover .flex-direction-nav .flex-next {
+  visibility: visible;
   opacity: 0.7;
   right: 10px;
 }


### PR DESCRIPTION
You should use opacity + visibility in combination, otherwise the nav elements are still hoverable (can lead to conflicts with siders besides)
