### PR TITLE
control parameter of slider loop

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -322,6 +322,13 @@
             var target;
 
             if (watchedEvent === "" || watchedEvent === event.type) {
+              // control loop
+              if (!options.loop) {
+                var disabledClass = namespace + 'disabled';
+                if ($(this).hasClass(disabledClass)) {
+                  return;
+                }
+              }
               target = ($(this).hasClass(namespace + 'next')) ? slider.getTarget('next') : slider.getTarget('prev');
               slider.flexAnimate(target, slider.vars.pauseOnAction);
             }
@@ -1150,6 +1157,7 @@
     maxItems: 0,                    //{NEW} Integer: Maxmimum number of carousel items that should be visible. Items will resize fluidly when above this limit.
     move: 0,                        //{NEW} Integer: Number of carousel items that should move on animation. If 0, slider will move all visible items.
     allowOneSlide: true,           //{NEW} Boolean: Whether or not to allow a slider comprised of a single slide
+    loop: true,                     //{NEW} Boolean: If true, slider repeats over and over again. If not, it's not repeated.
 
     // Callback API
     start: function(){},            //Callback: function(slider) - Fires when the slider loads the first slide


### PR DESCRIPTION
fix #1554
add parameter of control slider loop.

sample code.

```
    $('.flexslider').flexslider({
        animation: "slide",
        animationLoop: false,
        itemWidth: 405,
        itemMargin: 0,
        slideshow: false,
        loop: false
    });
```
