### PR TITLE
Fix Bug in FlexSlider

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -983,7 +983,7 @@
                        (slider.maxW < slider.w) ? (slider.w - (slideMargin * (maxItems - 1)))/maxItems :
                        (slider.vars.itemWidth > slider.w) ? slider.w : slider.vars.itemWidth;
 
-        slider.visible = Math.floor(slider.w/(slider.itemW));
+        slider.visible = Math.floor(slider.w/(slider.itemT));
         slider.move = (slider.vars.move > 0 && slider.vars.move < slider.visible ) ? slider.vars.move : slider.visible;
         slider.pagingCount = Math.ceil(((slider.count - slider.visible)/slider.move) + 1);
         slider.last =  slider.pagingCount - 1;


### PR DESCRIPTION
slider.visible was being set to a floor of slider width divided by item width. This change sets the variable to the floor of slider width divided by item total (item width + item margin). This prevents a bug where the slider would not function because it was calculating the item's width only and not it's full size.
