### PR TITLE
Allow Flexslider package to expose css

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.6.3",
   "description": "An awesome, fully responsive jQuery slider toolkit.",
   "main": "jquery.flexslider.js",
+  "style": "flexslider.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
By adding this field, npm modules like [sass-module-importer](https://www.npmjs.com/package/sass-module-importer) or [npm-css](https://www.npmjs.com/package/npm-css) can import the CSS from the Flexslider `npm_modules` folder.

EG.
`@import 'flexslider';`

Fix for [#1616](https://github.com/woocommerce/FlexSlider/issues/1616)