### PR TITLE
Feature: Drag/Swipe slides using the mouse

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -142,6 +142,9 @@ Previously called "animationDuration" in v1.8 and below.
 ### touch: *{new}*
 `touch` allows users to exclude touch swipe functionality from their sliders.
 
+### simulateTouch: *{new}*
+`simulateTouch` allows users to interpret mouse events as touch events for swipe-like functionality from their sliders. Requires `touch` to be true.
+
 ### keyboard: *{changed}*
 Previously called "keyboardNav" in v1.8 and below.
 


### PR DESCRIPTION
Added a `simulateTouch` option, when true a slider will interpret mouse events as touch events. 
The option must be paired with a `touch` option set to true.
The option is false by default.