### PR TITLE
Fix 1676 Issue: Cannot pause animation via play/pause button in IE11

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -499,7 +499,13 @@
             el.style.msTouchAction = "none";
             el._gesture = new MSGesture();
             el._gesture.target = el;
-            el.addEventListener("MSPointerDown", onMSPointerDown, false);
+            var eventType;
+            if (window.navigator.pointerEnabled) {
+                eventType = "pointerDown";
+            } else if (window.navigator.msPointerEnabled) {
+                eventType = "MSPointerDown";
+            }
+            el.addEventListener(eventType, onMSPointerDown, false);
             el._slider = slider;
             el.addEventListener("MSGestureChange", onMSGestureChange, false);
             el.addEventListener("MSGestureEnd", onMSGestureEnd, false);


### PR DESCRIPTION
The reason: the event type available in the event handler equals MSPointerDown in IE10 and pointerdown in IE 11. This is not compatible with the way jQuery refers event handlers (as far as I debugged it, the problem happens here. ). The event handler is not resolved, and never gets called.

See https://coderwall.com/p/mfreca/ie-11-in-windows-8-1-pointer-events-changes
