### PR TITLE
'slide' aria-label attribute added to <a> tags

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -241,7 +241,7 @@
                 slide.attr( 'data-thumb-alt', '' ); 
               }
               
-              item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
+              item = $( '<a></a>' ).attr( 'href', '#' ).attr('aria-label', 'Slide').text( j );
               if ( slider.vars.controlNav === "thumbnails" ) {
                 item = $( '<img/>' ).attr( 'src', slide.attr( 'data-thumb' ) );
               }
@@ -328,7 +328,7 @@
         },
         update: function(action, pos) {
           if (slider.pagingCount > 1 && action === "add") {
-            slider.controlNavScaffold.append($('<li><a href="#">' + slider.count + '</a></li>'));
+            slider.controlNavScaffold.append($('<li><a href="#" aria-label="Slide">' + slider.count + '</a></li>'));
           } else if (slider.pagingCount === 1) {
             slider.controlNavScaffold.find('li').remove();
           } else {

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -9,52 +9,56 @@
   var focused = true;
 
   //FlexSlider: Object Instance
-  $.flexslider = function(el, options) {
+  $.flexslider = function (el, options) {
     var slider = $(el);
 
     // making variables public
 
     //if rtl value was not passed and html is in rtl..enable it by default.
-    if(typeof options.rtl=='undefined' && $('html').attr('dir')=='rtl'){
-      options.rtl=true;
+    if (typeof options.rtl == 'undefined' && $('html').attr('dir') == 'rtl') {
+      options.rtl = true;
     }
     slider.vars = $.extend({}, $.flexslider.defaults, options);
 
     var namespace = slider.vars.namespace,
-        msGesture = window.navigator && window.navigator.msPointerEnabled && window.MSGesture,
-        touch = (( "ontouchstart" in window ) || msGesture || window.DocumentTouch && document instanceof DocumentTouch) && slider.vars.touch,
-        // deprecating this idea, as devices are being released with both of these events
-        eventType = "click touchend MSPointerUp keyup",
-        watchedEvent = "",
-        watchedEventClearTimer,
-        vertical = slider.vars.direction === "vertical",
-        reverse = slider.vars.reverse,
-        carousel = (slider.vars.itemWidth > 0),
-        fade = slider.vars.animation === "fade",
-        asNav = slider.vars.asNavFor !== "",
-        methods = {};
+      msGesture = window.navigator && window.navigator.msPointerEnabled && window.MSGesture,
+      touch = (("ontouchstart" in window) || msGesture || window.DocumentTouch && document instanceof DocumentTouch) && slider.vars.touch,
+      // deprecating this idea, as devices are being released with both of these events
+      eventType = "click touchend MSPointerUp keyup",
+      watchedEvent = "",
+      watchedEventClearTimer,
+      vertical = slider.vars.direction === "vertical",
+      reverse = slider.vars.reverse,
+      carousel = (slider.vars.itemWidth > 0),
+      fade = slider.vars.animation === "fade",
+      asNav = slider.vars.asNavFor !== "",
+      methods = {};
 
     // Store a reference to the slider object
     $.data(el, "flexslider", slider);
 
     // Private slider methods
     methods = {
-      init: function() {
+      init: function () {
         slider.animating = false;
         // Get current slide and make sure it is a number
-        slider.currentSlide = parseInt( ( slider.vars.startAt ? slider.vars.startAt : 0), 10 );
-        if ( isNaN( slider.currentSlide ) ) { slider.currentSlide = 0; }
+        slider.currentSlide = parseInt((slider.vars.startAt ? slider.vars.startAt : 0), 10);
+        if (isNaN(slider.currentSlide)) {
+          slider.currentSlide = 0;
+        }
         slider.animatingTo = slider.currentSlide;
         slider.atEnd = (slider.currentSlide === 0 || slider.currentSlide === slider.last);
-        slider.containerSelector = slider.vars.selector.substr(0,slider.vars.selector.search(' '));
+        slider.containerSelector = slider.vars.selector.substr(0, slider.vars.selector.search(' '));
         slider.slides = $(slider.vars.selector, slider);
         slider.container = $(slider.containerSelector, slider);
         slider.count = slider.slides.length;
         // SYNC:
         slider.syncExists = $(slider.vars.sync).length > 0;
         // SLIDE:
-        if (slider.vars.animation === "slide") { slider.vars.animation = "swing"; }
-        slider.prop = (vertical) ? "top" : ( slider.vars.rtl ? "marginRight" : "marginLeft" );
+        if (slider.vars.animation === "slide") {
+          slider.vars.animation = "swing";
+        }
+        slider.prop = (vertical) ? "top" : (slider.vars.rtl ? "marginRight" : "marginLeft");
         slider.args = {};
         // SLIDESHOW:
         slider.manualPause = false;
@@ -63,12 +67,12 @@
         slider.started = false;
         slider.startTimeout = null;
         // TOUCH/USECSS:
-        slider.transitions = !slider.vars.video && !fade && slider.vars.useCSS && (function() {
+        slider.transitions = !slider.vars.video && !fade && slider.vars.useCSS && (function () {
           var obj = document.createElement('div'),
-              props = ['perspectiveProperty', 'WebkitPerspective', 'MozPerspective', 'OPerspective', 'msPerspective'];
+            props = ['perspectiveProperty', 'WebkitPerspective', 'MozPerspective', 'OPerspective', 'msPerspective'];
           for (var i in props) {
-            if ( obj.style[ props[i] ] !== undefined ) {
-              slider.pfx = props[i].replace('Perspective','').toLowerCase();
+            if (obj.style[props[i]] !== undefined) {
+              slider.pfx = props[i].replace('Perspective', '').toLowerCase();
               slider.prop = "-" + slider.pfx + "-transform";
               return true;
             }
@@ -87,7 +91,9 @@
 
         // RANDOMIZE:
         if (slider.vars.randomize) {
-          slider.slides.sort(function() { return (Math.round(Math.random())-0.5); });
+          slider.slides.sort(function () {
+            return (Math.round(Math.random()) - 0.5);
+          });
           slider.container.empty().append(slider.slides);
         }
 
@@ -97,31 +103,35 @@
         slider.setup("init");
 
         // CONTROLNAV:
-        if (slider.vars.controlNav) { methods.controlNav.setup(); }
+        if (slider.vars.controlNav) {
+          methods.controlNav.setup();
+        }
 
         // DIRECTIONNAV:
-        if (slider.vars.directionNav) { methods.directionNav.setup(); }
+        if (slider.vars.directionNav) {
+          methods.directionNav.setup();
+        }
 
         // KEYBOARD:
         if (slider.vars.keyboard && ($(slider.containerSelector).length === 1 || slider.vars.multipleKeyboard)) {
-          $(document).bind('keyup', function(event) {
+          $(document).bind('keyup', function (event) {
             var keycode = event.keyCode;
             if (!slider.animating && (keycode === 39 || keycode === 37)) {
-              var target = (slider.vars.rtl?
-                                ((keycode === 37) ? slider.getTarget('next') :
-                                (keycode === 39) ? slider.getTarget('prev') : false)
-                                :
-                                ((keycode === 39) ? slider.getTarget('next') :
-                                (keycode === 37) ? slider.getTarget('prev') : false)
-                                )
-                                ;
+              var target = (slider.vars.rtl ?
+                  ((keycode === 37) ? slider.getTarget('next') :
+                    (keycode === 39) ? slider.getTarget('prev') : false)
+                  :
+                  ((keycode === 39) ? slider.getTarget('next') :
+                    (keycode === 37) ? slider.getTarget('prev') : false)
+                )
+              ;
               slider.flexAnimate(target, slider.vars.pauseOnAction);
             }
           });
         }
         // MOUSEWHEEL:
         if (slider.vars.mousewheel) {
-          slider.bind('mousewheel', function(event, delta, deltaX, deltaY) {
+          slider.bind('mousewheel', function (event, delta, deltaX, deltaY) {
             event.preventDefault();
             var target = (delta < 0) ? slider.getTarget('next') : slider.getTarget('prev');
             slider.flexAnimate(target, slider.vars.pauseOnAction);
@@ -129,138 +139,150 @@
         }
 
         // PAUSEPLAY
-        if (slider.vars.pausePlay) { methods.pausePlay.setup(); }
+        if (slider.vars.pausePlay) {
+          methods.pausePlay.setup();
+        }
 
         //PAUSE WHEN INVISIBLE
-        if (slider.vars.slideshow && slider.vars.pauseInvisible) { methods.pauseInvisible.init(); }
+        if (slider.vars.slideshow && slider.vars.pauseInvisible) {
+          methods.pauseInvisible.init();
+        }
 
         // SLIDSESHOW
         if (slider.vars.slideshow) {
           if (slider.vars.pauseOnHover) {
-            slider.hover(function() {
-              if (!slider.manualPlay && !slider.manualPause) { slider.pause(); }
-            }, function() {
-              if (!slider.manualPause && !slider.manualPlay && !slider.stopped) { slider.play(); }
+            slider.hover(function () {
+              if (!slider.manualPlay && !slider.manualPause) {
+                slider.pause();
+              }
+            }, function () {
+              if (!slider.manualPause && !slider.manualPlay && !slider.stopped) {
+                slider.play();
+              }
             });
           }
           // initialize animation
           //If we're visible, or we don't use PageVisibility API
-          if(!slider.vars.pauseInvisible || !methods.pauseInvisible.isHidden()) {
+          if (!slider.vars.pauseInvisible || !methods.pauseInvisible.isHidden()) {
             (slider.vars.initDelay > 0) ? slider.startTimeout = setTimeout(slider.play, slider.vars.initDelay) : slider.play();
           }
         }
 
         // ASNAV:
-        if (asNav) { methods.asNav.setup(); }
+        if (asNav) {
+          methods.asNav.setup();
+        }
 
         // TOUCH
-        if (touch && slider.vars.touch) { methods.touch(); }
+        if (touch && slider.vars.touch) {
+          methods.touch();
+        }
 
         // FADE&&SMOOTHHEIGHT || SLIDE:
-        if (!fade || (fade && slider.vars.smoothHeight)) { $(window).bind("resize orientationchange focus", methods.resize); }
+        if (!fade || (fade && slider.vars.smoothHeight)) {
+          $(window).bind("resize orientationchange focus", methods.resize);
+        }
 
         slider.find("img").attr("draggable", "false");
 
         // API: start() Callback
-        setTimeout(function(){
+        setTimeout(function () {
           slider.vars.start(slider);
         }, 200);
       },
       asNav: {
-        setup: function() {
+        setup: function () {
           slider.asNav = true;
-          slider.animatingTo = Math.floor(slider.currentSlide/slider.move);
+          slider.animatingTo = Math.floor(slider.currentSlide / slider.move);
           slider.currentItem = slider.currentSlide;
           slider.slides.removeClass(namespace + "active-slide").eq(slider.currentItem).addClass(namespace + "active-slide");
-          if(!msGesture){
-              slider.slides.on(eventType, function(e){
+          if (!msGesture) {
+            slider.slides.on(eventType, function (e) {
+              e.preventDefault();
+              var $slide = $(this),
+                target = $slide.index();
+              var posFromX;
+              if (slider.vars.rtl) {
+                posFromX = -1 * ($slide.offset().right - $(slider).scrollLeft()); // Find position of slide relative to right of slider container
+              } else {
+                posFromX = $slide.offset().left - $(slider).scrollLeft(); // Find position of slide relative to left of slider container
+              }
+              if (posFromX <= 0 && $slide.hasClass(namespace + 'active-slide')) {
+                slider.flexAnimate(slider.getTarget("prev"), true);
+              } else if (!$(slider.vars.asNavFor).data('flexslider').animating && !$slide.hasClass(namespace + "active-slide")) {
+                slider.direction = (slider.currentItem < target) ? "next" : "prev";
+                slider.flexAnimate(target, slider.vars.pauseOnAction, false, true, true);
+              }
+            });
+          } else {
+            el._slider = slider;
+            slider.slides.each(function () {
+              var that = this;
+              that._gesture = new MSGesture();
+              that._gesture.target = that;
+              that.addEventListener("MSPointerDown", function (e) {
+                e.preventDefault();
+                if (e.currentTarget._gesture) {
+                  e.currentTarget._gesture.addPointer(e.pointerId);
+                }
+              }, false);
+              that.addEventListener("MSGestureTap", function (e) {
                 e.preventDefault();
                 var $slide = $(this),
-                    target = $slide.index();
-                var posFromX;
-                if(slider.vars.rtl){
-                  posFromX = -1*($slide.offset().right - $(slider).scrollLeft()); // Find position of slide relative to right of slider container
-                }
-                else
-                {
-                  posFromX = $slide.offset().left - $(slider).scrollLeft(); // Find position of slide relative to left of slider container
-                }
-                if( posFromX <= 0 && $slide.hasClass( namespace + 'active-slide' ) ) {
-                  slider.flexAnimate(slider.getTarget("prev"), true);
-                } else if (!$(slider.vars.asNavFor).data('flexslider').animating && !$slide.hasClass(namespace + "active-slide")) {
+                  target = $slide.index();
+                if (!$(slider.vars.asNavFor).data('flexslider').animating && !$slide.hasClass('active')) {
                   slider.direction = (slider.currentItem < target) ? "next" : "prev";
                   slider.flexAnimate(target, slider.vars.pauseOnAction, false, true, true);
                 }
               });
-          }else{
-              el._slider = slider;
-              slider.slides.each(function (){
-                  var that = this;
-                  that._gesture = new MSGesture();
-                  that._gesture.target = that;
-                  that.addEventListener("MSPointerDown", function (e){
-                      e.preventDefault();
-                      if(e.currentTarget._gesture) {
-                        e.currentTarget._gesture.addPointer(e.pointerId);
-                      }
-                  }, false);
-                  that.addEventListener("MSGestureTap", function (e){
-                      e.preventDefault();
-                      var $slide = $(this),
-                          target = $slide.index();
-                      if (!$(slider.vars.asNavFor).data('flexslider').animating && !$slide.hasClass('active')) {
-                          slider.direction = (slider.currentItem < target) ? "next" : "prev";
-                          slider.flexAnimate(target, slider.vars.pauseOnAction, false, true, true);
-                      }
-                  });
-              });
+            });
           }
         }
       },
       controlNav: {
-        setup: function() {
+        setup: function () {
           if (!slider.manualControls) {
             methods.controlNav.setupPaging();
           } else { // MANUALCONTROLS:
             methods.controlNav.setupManual();
           }
         },
-        setupPaging: function() {
+        setupPaging: function () {
           var type = (slider.vars.controlNav === "thumbnails") ? 'control-thumbs' : 'control-paging',
-              j = 1,
-              item,
-              slide;
+            j = 1,
+            item,
+            slide;
 
-          slider.controlNavScaffold = $('<ol class="'+ namespace + 'control-nav ' + namespace + type + '"></ol>');
+          slider.controlNavScaffold = $('<ol class="' + namespace + 'control-nav ' + namespace + type + '"></ol>');
 
           if (slider.pagingCount > 1) {
             for (var i = 0; i < slider.pagingCount; i++) {
               slide = slider.slides.eq(i);
 
-              if ( undefined === slide.attr( 'data-thumb-alt' ) ) { 
-                slide.attr( 'data-thumb-alt', '' ); 
-              }
-              
-              item = $( '<a></a>' ).attr( 'href', '#' ).attr('aria-label', 'Slide').text( j );
-              if ( slider.vars.controlNav === "thumbnails" ) {
-                item = $( '<img/>' ).attr( 'src', slide.attr( 'data-thumb' ) );
-              }
-              
-              if ( '' !== slide.attr( 'data-thumb-alt' ) ) {
-                item.attr( 'alt', slide.attr( 'data-thumb-alt' ) );
+              if (undefined === slide.attr('data-thumb-alt')) {
+                slide.attr('data-thumb-alt', '');
               }
 
-              if ( 'thumbnails' === slider.vars.controlNav && true === slider.vars.thumbCaptions ) {
-                var captn = slide.attr( 'data-thumbcaption' );
-                if ( '' !== captn && undefined !== captn ) { 
-                  var caption = $('<span></span>' ).addClass( namespace + 'caption' ).text( captn );
-                  item.append( caption );
+              item = $('<a></a>').attr('href', '#').attr('aria-label', 'Slide').text(j);
+              if (slider.vars.controlNav === "thumbnails") {
+                item = $('<img/>').attr('src', slide.attr('data-thumb'));
+              }
+
+              if ('' !== slide.attr('data-thumb-alt')) {
+                item.attr('alt', slide.attr('data-thumb-alt'));
+              }
+
+              if ('thumbnails' === slider.vars.controlNav && true === slider.vars.thumbCaptions) {
+                var captn = slide.attr('data-thumbcaption');
+                if ('' !== captn && undefined !== captn) {
+                  var caption = $('<span></span>').addClass(namespace + 'caption').text(captn);
+                  item.append(caption);
                 }
               }
-              
-              var liElement = $( '<li>' );
-              item.appendTo( liElement );
-              liElement.append( '</li>' );
+
+              var liElement = $('<li>');
+              item.appendTo(liElement);
+              liElement.append('</li>');
 
               slider.controlNavScaffold.append(liElement);
               j++;
@@ -274,12 +296,12 @@
 
           methods.controlNav.active();
 
-          slider.controlNavScaffold.delegate('a, img', eventType, function(event) {
+          slider.controlNavScaffold.delegate('a, img', eventType, function (event) {
             event.preventDefault();
 
             if (watchedEvent === "" || watchedEvent === event.type) {
               var $this = $(this),
-                  target = slider.controlNav.index($this);
+                target = slider.controlNav.index($this);
 
               if (!$this.hasClass(namespace + 'active')) {
                 slider.direction = (target > slider.currentSlide) ? "next" : "prev";
@@ -295,16 +317,16 @@
 
           });
         },
-        setupManual: function() {
+        setupManual: function () {
           slider.controlNav = slider.manualControls;
           methods.controlNav.active();
 
-          slider.controlNav.bind(eventType, function(event) {
+          slider.controlNav.bind(eventType, function (event) {
             event.preventDefault();
 
             if (watchedEvent === "" || watchedEvent === event.type) {
               var $this = $(this),
-                  target = slider.controlNav.index($this);
+                target = slider.controlNav.index($this);
 
               if (!$this.hasClass(namespace + 'active')) {
                 (target > slider.currentSlide) ? slider.direction = "next" : slider.direction = "prev";
@@ -319,14 +341,14 @@
             methods.setToClearWatchedEvent();
           });
         },
-        set: function() {
+        set: function () {
           var selector = (slider.vars.controlNav === "thumbnails") ? 'img' : 'a';
           slider.controlNav = $('.' + namespace + 'control-nav li ' + selector, (slider.controlsContainer) ? slider.controlsContainer : slider);
         },
-        active: function() {
+        active: function () {
           slider.controlNav.removeClass(namespace + "active").eq(slider.animatingTo).addClass(namespace + "active");
         },
-        update: function(action, pos) {
+        update: function (action, pos) {
           if (slider.pagingCount > 1 && action === "add") {
             slider.controlNavScaffold.append($('<li><a href="#" aria-label="Slide">' + slider.count + '</a></li>'));
           } else if (slider.pagingCount === 1) {
@@ -339,14 +361,14 @@
         }
       },
       directionNav: {
-        setup: function() {
+        setup: function () {
           if (slider.pagingCount > 1) {
             var directionNavScaffold = $('<ul class="' + namespace + 'direction-nav"><li class="' + namespace + 'nav-prev"><a class="' + namespace + 'prev" href="#">' + slider.vars.prevText + '</a></li><li class="' + namespace + 'nav-next"><a class="' + namespace + 'next" href="#">' + slider.vars.nextText + '</a></li></ul>');
 
             // CUSTOM DIRECTION NAV:
             if (slider.customDirectionNav) {
               slider.directionNav = slider.customDirectionNav;
-            // CONTROLSCONTAINER:
+              // CONTROLSCONTAINER:
             } else if (slider.controlsContainer) {
               $(slider.controlsContainer).append(directionNavScaffold);
               slider.directionNav = $('.' + namespace + 'direction-nav li a', slider.controlsContainer);
@@ -357,7 +379,7 @@
 
             methods.directionNav.update();
 
-            slider.directionNav.bind(eventType, function(event) {
+            slider.directionNav.bind(eventType, function (event) {
               event.preventDefault();
               var target;
 
@@ -374,7 +396,7 @@
             });
           }
         },
-        update: function() {
+        update: function () {
           var disabledClass = namespace + 'disabled';
           if (slider.pagingCount === 1) {
             slider.directionNav.addClass(disabledClass).attr('tabindex', '-1');
@@ -392,7 +414,7 @@
         }
       },
       pausePlay: {
-        setup: function() {
+        setup: function () {
           var pausePlayScaffold = $('<div class="' + namespace + 'pauseplay"><a href="#"></a></div>');
 
           // CONTROLSCONTAINER:
@@ -406,7 +428,7 @@
 
           methods.pausePlay.update((slider.vars.slideshow) ? namespace + 'pause' : namespace + 'play');
 
-          slider.pausePlay.bind(eventType, function(event) {
+          slider.pausePlay.bind(eventType, function (event) {
             event.preventDefault();
 
             if (watchedEvent === "" || watchedEvent === event.type) {
@@ -428,11 +450,11 @@
             methods.setToClearWatchedEvent();
           });
         },
-        update: function(state) {
+        update: function (state) {
           (state === "play") ? slider.pausePlay.removeClass(namespace + 'pause').addClass(namespace + 'play').html(slider.vars.playText) : slider.pausePlay.removeClass(namespace + 'play').addClass(namespace + 'pause').html(slider.vars.pauseText);
         }
       },
-      touch: function() {
+      touch: function () {
         var startX,
           startY,
           offset,
@@ -447,167 +469,173 @@
           localY = 0,
           accDx = 0;
 
-        if(!msGesture){
-            onTouchStart = function(e) {
-              if (slider.animating) {
-                e.preventDefault();
-              } else if ( ( window.navigator.msPointerEnabled ) || e.touches.length === 1 ) {
-                slider.pause();
-                // CAROUSEL:
-                cwidth = (vertical) ? slider.h : slider. w;
-                startT = Number(new Date());
-                // CAROUSEL:
+        if (!msGesture) {
+          onTouchStart = function (e) {
+            if (slider.animating) {
+              e.preventDefault();
+            } else if ((window.navigator.msPointerEnabled) || e.touches.length === 1) {
+              slider.pause();
+              // CAROUSEL:
+              cwidth = (vertical) ? slider.h : slider.w;
+              startT = Number(new Date());
+              // CAROUSEL:
 
-                // Local vars for X and Y points.
-                localX = e.touches[0].pageX;
-                localY = e.touches[0].pageY;
-
-                offset = (carousel && reverse && slider.animatingTo === slider.last) ? 0 :
-                         (carousel && reverse) ? slider.limit - (((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.animatingTo) :
-                         (carousel && slider.currentSlide === slider.last) ? slider.limit :
-                         (carousel) ? ((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.currentSlide :
-                         (reverse) ? (slider.last - slider.currentSlide + slider.cloneOffset) * cwidth : (slider.currentSlide + slider.cloneOffset) * cwidth;
-                startX = (vertical) ? localY : localX;
-                startY = (vertical) ? localX : localY;
-                el.addEventListener('touchmove', onTouchMove, false);
-                el.addEventListener('touchend', onTouchEnd, false);
-              }
-            };
-
-            onTouchMove = function(e) {
               // Local vars for X and Y points.
-
               localX = e.touches[0].pageX;
               localY = e.touches[0].pageY;
 
-              dx = (vertical) ? startX - localY : (slider.vars.rtl?-1:1)*(startX - localX);
-              scrolling = (vertical) ? (Math.abs(dx) < Math.abs(localX - startY)) : (Math.abs(dx) < Math.abs(localY - startY));
-              var fxms = 500;
+              offset = (carousel && reverse && slider.animatingTo === slider.last) ? 0 :
+                (carousel && reverse) ? slider.limit - (((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.animatingTo) :
+                  (carousel && slider.currentSlide === slider.last) ? slider.limit :
+                    (carousel) ? ((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.currentSlide :
+                      (reverse) ? (slider.last - slider.currentSlide + slider.cloneOffset) * cwidth : (slider.currentSlide + slider.cloneOffset) * cwidth;
+              startX = (vertical) ? localY : localX;
+              startY = (vertical) ? localX : localY;
+              el.addEventListener('touchmove', onTouchMove, false);
+              el.addEventListener('touchend', onTouchEnd, false);
+            }
+          };
 
-              if ( ! scrolling || Number( new Date() ) - startT > fxms ) {
-                e.preventDefault();
-                if (!fade && slider.transitions) {
-                  if (!slider.vars.animationLoop) {
-                    dx = dx/((slider.currentSlide === 0 && dx < 0 || slider.currentSlide === slider.last && dx > 0) ? (Math.abs(dx)/cwidth+2) : 1);
-                  }
-                  slider.setProps(offset + dx, "setTouch");
+          onTouchMove = function (e) {
+            // Local vars for X and Y points.
+
+            localX = e.touches[0].pageX;
+            localY = e.touches[0].pageY;
+
+            dx = (vertical) ? startX - localY : (slider.vars.rtl ? -1 : 1) * (startX - localX);
+            scrolling = (vertical) ? (Math.abs(dx) < Math.abs(localX - startY)) : (Math.abs(dx) < Math.abs(localY - startY));
+            var fxms = 500;
+
+            if (!scrolling || Number(new Date()) - startT > fxms) {
+              e.preventDefault();
+              if (!fade && slider.transitions) {
+                if (!slider.vars.animationLoop) {
+                  dx = dx / ((slider.currentSlide === 0 && dx < 0 || slider.currentSlide === slider.last && dx > 0) ? (Math.abs(dx) / cwidth + 2) : 1);
+                }
+                slider.setProps(offset + dx, "setTouch");
+              }
+            }
+          };
+
+          onTouchEnd = function (e) {
+            // finish the touch by undoing the touch session
+            el.removeEventListener('touchmove', onTouchMove, false);
+
+            if (slider.animatingTo === slider.currentSlide && !scrolling && !(dx === null)) {
+              var updateDx = (reverse) ? -dx : dx,
+                target = (updateDx > 0) ? slider.getTarget('next') : slider.getTarget('prev');
+
+              if (slider.canAdvance(target) && (Number(new Date()) - startT < 550 && Math.abs(updateDx) > 50 || Math.abs(updateDx) > cwidth / 2)) {
+                slider.flexAnimate(target, slider.vars.pauseOnAction);
+              } else {
+                if (!fade) {
+                  slider.flexAnimate(slider.currentSlide, slider.vars.pauseOnAction, true);
                 }
               }
-            };
+            }
+            el.removeEventListener('touchend', onTouchEnd, false);
 
-            onTouchEnd = function(e) {
-              // finish the touch by undoing the touch session
-              el.removeEventListener('touchmove', onTouchMove, false);
+            startX = null;
+            startY = null;
+            dx = null;
+            offset = null;
+          };
 
-              if (slider.animatingTo === slider.currentSlide && !scrolling && !(dx === null)) {
-                var updateDx = (reverse) ? -dx : dx,
-                    target = (updateDx > 0) ? slider.getTarget('next') : slider.getTarget('prev');
+          el.addEventListener('touchstart', onTouchStart, false);
+        } else {
+          el.style.msTouchAction = "none";
+          el._gesture = new MSGesture();
+          el._gesture.target = el;
+          el.addEventListener("MSPointerDown", onMSPointerDown, false);
+          el._slider = slider;
+          el.addEventListener("MSGestureChange", onMSGestureChange, false);
+          el.addEventListener("MSGestureEnd", onMSGestureEnd, false);
 
-                if (slider.canAdvance(target) && (Number(new Date()) - startT < 550 && Math.abs(updateDx) > 50 || Math.abs(updateDx) > cwidth/2)) {
-                  slider.flexAnimate(target, slider.vars.pauseOnAction);
-                } else {
-                  if (!fade) { slider.flexAnimate(slider.currentSlide, slider.vars.pauseOnAction, true); }
+          function onMSPointerDown(e) {
+            e.stopPropagation();
+            if (slider.animating) {
+              e.preventDefault();
+            } else {
+              slider.pause();
+              el._gesture.addPointer(e.pointerId);
+              accDx = 0;
+              cwidth = (vertical) ? slider.h : slider.w;
+              startT = Number(new Date());
+              // CAROUSEL:
+
+              offset = (carousel && reverse && slider.animatingTo === slider.last) ? 0 :
+                (carousel && reverse) ? slider.limit - (((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.animatingTo) :
+                  (carousel && slider.currentSlide === slider.last) ? slider.limit :
+                    (carousel) ? ((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.currentSlide :
+                      (reverse) ? (slider.last - slider.currentSlide + slider.cloneOffset) * cwidth : (slider.currentSlide + slider.cloneOffset) * cwidth;
+            }
+          }
+
+          function onMSGestureChange(e) {
+            e.stopPropagation();
+            var slider = e.target._slider;
+            if (!slider) {
+              return;
+            }
+            var transX = -e.translationX,
+              transY = -e.translationY;
+
+            //Accumulate translations.
+            accDx = accDx + ((vertical) ? transY : transX);
+            dx = (slider.vars.rtl ? -1 : 1) * accDx;
+            scrolling = (vertical) ? (Math.abs(accDx) < Math.abs(-transX)) : (Math.abs(accDx) < Math.abs(-transY));
+
+            if (e.detail === e.MSGESTURE_FLAG_INERTIA) {
+              setImmediate(function () {
+                el._gesture.stop();
+              });
+
+              return;
+            }
+
+            if (!scrolling || Number(new Date()) - startT > 500) {
+              e.preventDefault();
+              if (!fade && slider.transitions) {
+                if (!slider.vars.animationLoop) {
+                  dx = accDx / ((slider.currentSlide === 0 && accDx < 0 || slider.currentSlide === slider.last && accDx > 0) ? (Math.abs(accDx) / cwidth + 2) : 1);
+                }
+                slider.setProps(offset + dx, "setTouch");
+              }
+            }
+          }
+
+          function onMSGestureEnd(e) {
+            e.stopPropagation();
+            var slider = e.target._slider;
+            if (!slider) {
+              return;
+            }
+            if (slider.animatingTo === slider.currentSlide && !scrolling && !(dx === null)) {
+              var updateDx = (reverse) ? -dx : dx,
+                target = (updateDx > 0) ? slider.getTarget('next') : slider.getTarget('prev');
+
+              if (slider.canAdvance(target) && (Number(new Date()) - startT < 550 && Math.abs(updateDx) > 50 || Math.abs(updateDx) > cwidth / 2)) {
+                slider.flexAnimate(target, slider.vars.pauseOnAction);
+              } else {
+                if (!fade) {
+                  slider.flexAnimate(slider.currentSlide, slider.vars.pauseOnAction, true);
                 }
               }
-              el.removeEventListener('touchend', onTouchEnd, false);
-
-              startX = null;
-              startY = null;
-              dx = null;
-              offset = null;
-            };
-
-            el.addEventListener('touchstart', onTouchStart, false);
-        }else{
-            el.style.msTouchAction = "none";
-            el._gesture = new MSGesture();
-            el._gesture.target = el;
-            el.addEventListener("MSPointerDown", onMSPointerDown, false);
-            el._slider = slider;
-            el.addEventListener("MSGestureChange", onMSGestureChange, false);
-            el.addEventListener("MSGestureEnd", onMSGestureEnd, false);
-
-            function onMSPointerDown(e){
-                e.stopPropagation();
-                if (slider.animating) {
-                    e.preventDefault();
-                }else{
-                    slider.pause();
-                    el._gesture.addPointer(e.pointerId);
-                    accDx = 0;
-                    cwidth = (vertical) ? slider.h : slider. w;
-                    startT = Number(new Date());
-                    // CAROUSEL:
-
-                    offset = (carousel && reverse && slider.animatingTo === slider.last) ? 0 :
-                        (carousel && reverse) ? slider.limit - (((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.animatingTo) :
-                            (carousel && slider.currentSlide === slider.last) ? slider.limit :
-                                (carousel) ? ((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.currentSlide :
-                                    (reverse) ? (slider.last - slider.currentSlide + slider.cloneOffset) * cwidth : (slider.currentSlide + slider.cloneOffset) * cwidth;
-                }
             }
 
-            function onMSGestureChange(e) {
-                e.stopPropagation();
-                var slider = e.target._slider;
-                if(!slider){
-                    return;
-                }
-                var transX = -e.translationX,
-                    transY = -e.translationY;
-
-                //Accumulate translations.
-                accDx = accDx + ((vertical) ? transY : transX);
-                dx = (slider.vars.rtl?-1:1)*accDx;
-                scrolling = (vertical) ? (Math.abs(accDx) < Math.abs(-transX)) : (Math.abs(accDx) < Math.abs(-transY));
-
-                if(e.detail === e.MSGESTURE_FLAG_INERTIA){
-                    setImmediate(function (){
-                        el._gesture.stop();
-                    });
-
-                    return;
-                }
-
-                if (!scrolling || Number(new Date()) - startT > 500) {
-                    e.preventDefault();
-                    if (!fade && slider.transitions) {
-                        if (!slider.vars.animationLoop) {
-                            dx = accDx / ((slider.currentSlide === 0 && accDx < 0 || slider.currentSlide === slider.last && accDx > 0) ? (Math.abs(accDx) / cwidth + 2) : 1);
-                        }
-                        slider.setProps(offset + dx, "setTouch");
-                    }
-                }
-            }
-
-            function onMSGestureEnd(e) {
-                e.stopPropagation();
-                var slider = e.target._slider;
-                if(!slider){
-                    return;
-                }
-                if (slider.animatingTo === slider.currentSlide && !scrolling && !(dx === null)) {
-                    var updateDx = (reverse) ? -dx : dx,
-                        target = (updateDx > 0) ? slider.getTarget('next') : slider.getTarget('prev');
-
-                    if (slider.canAdvance(target) && (Number(new Date()) - startT < 550 && Math.abs(updateDx) > 50 || Math.abs(updateDx) > cwidth/2)) {
-                        slider.flexAnimate(target, slider.vars.pauseOnAction);
-                    } else {
-                        if (!fade) { slider.flexAnimate(slider.currentSlide, slider.vars.pauseOnAction, true); }
-                    }
-                }
-
-                startX = null;
-                startY = null;
-                dx = null;
-                offset = null;
-                accDx = 0;
-            }
+            startX = null;
+            startY = null;
+            dx = null;
+            offset = null;
+            accDx = 0;
+          }
         }
       },
-      resize: function() {
+      resize: function () {
         if (!slider.animating && slider.is(':visible')) {
-          if (!carousel) { slider.doMath(); }
+          if (!carousel) {
+            slider.doMath();
+          }
 
           if (fade) {
             // SMOOTH HEIGHT:
@@ -616,58 +644,66 @@
             slider.slides.width(slider.computedW);
             slider.update(slider.pagingCount);
             slider.setProps();
-          }
-          else if (vertical) { //VERTICAL:
+          } else if (vertical) { //VERTICAL:
             slider.viewport.height(slider.h);
             slider.setProps(slider.h, "setTotal");
           } else {
             // SMOOTH HEIGHT:
-            if (slider.vars.smoothHeight) { methods.smoothHeight(); }
+            if (slider.vars.smoothHeight) {
+              methods.smoothHeight();
+            }
             slider.newSlides.width(slider.computedW);
             slider.setProps(slider.computedW, "setTotal");
           }
         }
       },
-      smoothHeight: function(dur) {
+      smoothHeight: function (dur) {
         if (!vertical || fade) {
           var $obj = (fade) ? slider : slider.viewport;
           (dur) ? $obj.animate({"height": slider.slides.eq(slider.animatingTo).innerHeight()}, dur) : $obj.innerHeight(slider.slides.eq(slider.animatingTo).innerHeight());
         }
       },
-      sync: function(action) {
+      sync: function (action) {
         var $obj = $(slider.vars.sync).data("flexslider"),
-            target = slider.animatingTo;
+          target = slider.animatingTo;
 
         switch (action) {
-          case "animate": $obj.flexAnimate(target, slider.vars.pauseOnAction, false, true); break;
-          case "play": if (!$obj.playing && !$obj.asNav) { $obj.play(); } break;
-          case "pause": $obj.pause(); break;
+          case "animate":
+            $obj.flexAnimate(target, slider.vars.pauseOnAction, false, true);
+            break;
+          case "play":
+            if (!$obj.playing && !$obj.asNav) {
+              $obj.play();
+            }
+            break;
+          case "pause":
+            $obj.pause();
+            break;
         }
       },
-      uniqueID: function($clone) {
+      uniqueID: function ($clone) {
         // Append _clone to current level and children elements with id attributes
-        $clone.filter( '[id]' ).add($clone.find( '[id]' )).each(function() {
+        $clone.filter('[id]').add($clone.find('[id]')).each(function () {
           var $this = $(this);
-          $this.attr( 'id', $this.attr( 'id' ) + '_clone' );
+          $this.attr('id', $this.attr('id') + '_clone');
         });
         return $clone;
       },
       pauseInvisible: {
         visProp: null,
-        init: function() {
+        init: function () {
           var visProp = methods.pauseInvisible.getHiddenProp();
           if (visProp) {
-            var evtname = visProp.replace(/[H|h]idden/,'') + 'visibilitychange';
-            document.addEventListener(evtname, function() {
+            var evtname = visProp.replace(/[H|h]idden/, '') + 'visibilitychange';
+            document.addEventListener(evtname, function () {
               if (methods.pauseInvisible.isHidden()) {
-                if(slider.startTimeout) {
+                if (slider.startTimeout) {
                   clearTimeout(slider.startTimeout); //If clock is ticking, stop timer and prevent from starting while invisible
                 } else {
                   slider.pause(); //Or just pause
                 }
-              }
-              else {
-                if(slider.started) {
+              } else {
+                if (slider.started) {
                   slider.play(); //Initiated before, just play
                 } else {
                   if (slider.vars.initDelay > 0) {
@@ -680,39 +716,39 @@
             });
           }
         },
-        isHidden: function() {
+        isHidden: function () {
           var prop = methods.pauseInvisible.getHiddenProp();
           if (!prop) {
             return false;
           }
           return document[prop];
         },
-        getHiddenProp: function() {
-          var prefixes = ['webkit','moz','ms','o'];
+        getHiddenProp: function () {
+          var prefixes = ['webkit', 'moz', 'ms', 'o'];
           // if 'hidden' is natively supported just return it
           if ('hidden' in document) {
             return 'hidden';
           }
           // otherwise loop over all the known prefixes until we find one
-          for ( var i = 0; i < prefixes.length; i++ ) {
-              if ((prefixes[i] + 'Hidden') in document) {
-                return prefixes[i] + 'Hidden';
-              }
+          for (var i = 0; i < prefixes.length; i++) {
+            if ((prefixes[i] + 'Hidden') in document) {
+              return prefixes[i] + 'Hidden';
+            }
           }
           // otherwise it's not supported
           return null;
         }
       },
-      setToClearWatchedEvent: function() {
+      setToClearWatchedEvent: function () {
         clearTimeout(watchedEventClearTimer);
-        watchedEventClearTimer = setTimeout(function() {
+        watchedEventClearTimer = setTimeout(function () {
           watchedEvent = "";
         }, 3000);
       }
     };
 
     // public methods
-    slider.flexAnimate = function(target, pause, override, withSync, fromNav) {
+    slider.flexAnimate = function (target, pause, override, withSync, fromNav) {
       if (!slider.vars.animationLoop && target !== slider.currentSlide) {
         slider.direction = (target > slider.currentSlide) ? "next" : "prev";
       }
@@ -727,10 +763,10 @@
           slider.direction = (slider.currentItem < target) ? "next" : "prev";
           master.direction = slider.direction;
 
-          if (Math.ceil((target + 1)/slider.visible) - 1 !== slider.currentSlide && target !== 0) {
+          if (Math.ceil((target + 1) / slider.visible) - 1 !== slider.currentSlide && target !== 0) {
             slider.currentItem = target;
             slider.slides.removeClass(namespace + "active-slide").eq(target).addClass(namespace + "active-slide");
-            target = Math.floor(target/slider.visible);
+            target = Math.floor(target / slider.visible);
           } else {
             slider.currentItem = target;
             slider.slides.removeClass(namespace + "active-slide").eq(target).addClass(namespace + "active-slide");
@@ -742,39 +778,51 @@
         slider.animatingTo = target;
 
         // SLIDESHOW:
-        if (pause) { slider.pause(); }
+        if (pause) {
+          slider.pause();
+        }
 
         // API: before() animation Callback
         slider.vars.before(slider);
 
         // SYNC:
-        if (slider.syncExists && !fromNav) { methods.sync("animate"); }
+        if (slider.syncExists && !fromNav) {
+          methods.sync("animate");
+        }
 
         // CONTROLNAV
-        if (slider.vars.controlNav) { methods.controlNav.active(); }
+        if (slider.vars.controlNav) {
+          methods.controlNav.active();
+        }
 
         // !CAROUSEL:
         // CANDIDATE: slide active class (for add/remove slide)
-        if (!carousel) { slider.slides.removeClass(namespace + 'active-slide').eq(target).addClass(namespace + 'active-slide'); }
+        if (!carousel) {
+          slider.slides.removeClass(namespace + 'active-slide').eq(target).addClass(namespace + 'active-slide');
+        }
 
         // INFINITE LOOP:
         // CANDIDATE: atEnd
         slider.atEnd = target === 0 || target === slider.last;
 
         // DIRECTIONNAV:
-        if (slider.vars.directionNav) { methods.directionNav.update(); }
+        if (slider.vars.directionNav) {
+          methods.directionNav.update();
+        }
 
         if (target === slider.last) {
           // API: end() of cycle Callback
           slider.vars.end(slider);
           // SLIDESHOW && !INFINITE LOOP:
-          if (!slider.vars.animationLoop) { slider.pause(); }
+          if (!slider.vars.animationLoop) {
+            slider.pause();
+          }
         }
 
         // SLIDE:
         if (!fade) {
           var dimension = (vertical) ? slider.slides.filter(':first').height() : slider.computedW,
-              margin, slideString, calcNext;
+            margin, slideString, calcNext;
 
           // INFINITE LOOP / REVERSE:
           if (carousel) {
@@ -797,19 +845,19 @@
 
             // Unbind previous transitionEnd events and re-bind new transitionEnd event
             slider.container.unbind("webkitTransitionEnd transitionend");
-            slider.container.bind("webkitTransitionEnd transitionend", function() {
+            slider.container.bind("webkitTransitionEnd transitionend", function () {
               clearTimeout(slider.ensureAnimationEnd);
               slider.wrapup(dimension);
             });
 
             // Insurance for the ever-so-fickle transitionEnd event
             clearTimeout(slider.ensureAnimationEnd);
-            slider.ensureAnimationEnd = setTimeout(function() {
+            slider.ensureAnimationEnd = setTimeout(function () {
               slider.wrapup(dimension);
             }, slider.vars.animationSpeed + 100);
 
           } else {
-            slider.container.animate(slider.args, slider.vars.animationSpeed, slider.vars.easing, function(){
+            slider.container.animate(slider.args, slider.vars.animationSpeed, slider.vars.easing, function () {
               slider.wrapup(dimension);
             });
           }
@@ -818,16 +866,18 @@
             slider.slides.eq(slider.currentSlide).css({"zIndex": 1}).animate({"opacity": 0}, slider.vars.animationSpeed, slider.vars.easing);
             slider.slides.eq(target).css({"zIndex": 2}).animate({"opacity": 1}, slider.vars.animationSpeed, slider.vars.easing, slider.wrapup);
           } else {
-            slider.slides.eq(slider.currentSlide).css({ "opacity": 0, "zIndex": 1 });
-            slider.slides.eq(target).css({ "opacity": 1, "zIndex": 2 });
+            slider.slides.eq(slider.currentSlide).css({"opacity": 0, "zIndex": 1});
+            slider.slides.eq(target).css({"opacity": 1, "zIndex": 2});
             slider.wrapup(dimension);
           }
         }
         // SMOOTH HEIGHT:
-        if (slider.vars.smoothHeight) { methods.smoothHeight(slider.vars.animationSpeed); }
+        if (slider.vars.smoothHeight) {
+          methods.smoothHeight(slider.vars.animationSpeed);
+        }
       }
     };
-    slider.wrapup = function(dimension) {
+    slider.wrapup = function (dimension) {
       // SLIDE:
       if (!fade && !carousel) {
         if (slider.currentSlide === 0 && slider.animatingTo === slider.last && slider.vars.animationLoop) {
@@ -843,47 +893,59 @@
     };
 
     // SLIDESHOW:
-    slider.animateSlides = function() {
-      if (!slider.animating && focused ) { slider.flexAnimate(slider.getTarget("next")); }
+    slider.animateSlides = function () {
+      if (!slider.animating && focused) {
+        slider.flexAnimate(slider.getTarget("next"));
+      }
     };
     // SLIDESHOW:
-    slider.pause = function() {
+    slider.pause = function () {
       clearInterval(slider.animatedSlides);
       slider.animatedSlides = null;
       slider.playing = false;
       // PAUSEPLAY:
-      if (slider.vars.pausePlay) { methods.pausePlay.update("play"); }
+      if (slider.vars.pausePlay) {
+        methods.pausePlay.update("play");
+      }
       // SYNC:
-      if (slider.syncExists) { methods.sync("pause"); }
+      if (slider.syncExists) {
+        methods.sync("pause");
+      }
     };
     // SLIDESHOW:
-    slider.play = function() {
-      if (slider.playing) { clearInterval(slider.animatedSlides); }
+    slider.play = function () {
+      if (slider.playing) {
+        clearInterval(slider.animatedSlides);
+      }
       slider.animatedSlides = slider.animatedSlides || setInterval(slider.animateSlides, slider.vars.slideshowSpeed);
       slider.started = slider.playing = true;
       // PAUSEPLAY:
-      if (slider.vars.pausePlay) { methods.pausePlay.update("pause"); }
+      if (slider.vars.pausePlay) {
+        methods.pausePlay.update("pause");
+      }
       // SYNC:
-      if (slider.syncExists) { methods.sync("play"); }
+      if (slider.syncExists) {
+        methods.sync("play");
+      }
     };
     // STOP:
     slider.stop = function () {
       slider.pause();
       slider.stopped = true;
     };
-    slider.canAdvance = function(target, fromNav) {
+    slider.canAdvance = function (target, fromNav) {
       // ASNAV:
       var last = (asNav) ? slider.pagingCount - 1 : slider.last;
       return (fromNav) ? true :
-             (asNav && slider.currentItem === slider.count - 1 && target === 0 && slider.direction === "prev") ? true :
-             (asNav && slider.currentItem === 0 && target === slider.pagingCount - 1 && slider.direction !== "next") ? false :
-             (target === slider.currentSlide && !asNav) ? false :
-             (slider.vars.animationLoop) ? true :
-             (slider.atEnd && slider.currentSlide === 0 && target === last && slider.direction !== "next") ? false :
-             (slider.atEnd && slider.currentSlide === last && target === 0 && slider.direction === "next") ? false :
-             true;
+        (asNav && slider.currentItem === slider.count - 1 && target === 0 && slider.direction === "prev") ? true :
+          (asNav && slider.currentItem === 0 && target === slider.pagingCount - 1 && slider.direction !== "next") ? false :
+            (target === slider.currentSlide && !asNav) ? false :
+              (slider.vars.animationLoop) ? true :
+                (slider.atEnd && slider.currentSlide === 0 && target === last && slider.direction !== "next") ? false :
+                  (slider.atEnd && slider.currentSlide === last && target === 0 && slider.direction === "next") ? false :
+                    true;
     };
-    slider.getTarget = function(dir) {
+    slider.getTarget = function (dir) {
       slider.direction = dir;
       if (dir === "next") {
         return (slider.currentSlide === slider.last) ? 0 : slider.currentSlide + 1;
@@ -893,53 +955,63 @@
     };
 
     // SLIDE:
-    slider.setProps = function(pos, special, dur) {
-      var target = (function() {
+    slider.setProps = function (pos, special, dur) {
+      var target = (function () {
         var posCheck = (pos) ? pos : ((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.animatingTo,
-            posCalc = (function() {
-              if (carousel) {
-                return (special === "setTouch") ? pos :
-                       (reverse && slider.animatingTo === slider.last) ? 0 :
-                       (reverse) ? slider.limit - (((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.animatingTo) :
-                       (slider.animatingTo === slider.last) ? slider.limit : posCheck;
-              } else {
-                switch (special) {
-                  case "setTotal": return (reverse) ? ((slider.count - 1) - slider.currentSlide + slider.cloneOffset) * pos : (slider.currentSlide + slider.cloneOffset) * pos;
-                  case "setTouch": return (reverse) ? pos : pos;
-                  case "jumpEnd": return (reverse) ? pos : slider.count * pos;
-                  case "jumpStart": return (reverse) ? slider.count * pos : pos;
-                  default: return pos;
-                }
+          posCalc = (function () {
+            if (carousel) {
+              return (special === "setTouch") ? pos :
+                (reverse && slider.animatingTo === slider.last) ? 0 :
+                  (reverse) ? slider.limit - (((slider.itemW + slider.vars.itemMargin) * slider.move) * slider.animatingTo) :
+                    (slider.animatingTo === slider.last) ? slider.limit : posCheck;
+            } else {
+              switch (special) {
+                case "setTotal":
+                  return (reverse) ? ((slider.count - 1) - slider.currentSlide + slider.cloneOffset) * pos : (slider.currentSlide + slider.cloneOffset) * pos;
+                case "setTouch":
+                  return (reverse) ? pos : pos;
+                case "jumpEnd":
+                  return (reverse) ? pos : slider.count * pos;
+                case "jumpStart":
+                  return (reverse) ? slider.count * pos : pos;
+                default:
+                  return pos;
               }
-            }());
-
-            return (posCalc * ((slider.vars.rtl)?1:-1)) + "px";
+            }
           }());
+
+        return (posCalc * ((slider.vars.rtl) ? 1 : -1)) + "px";
+      }());
 
       if (slider.transitions) {
         if (slider.isFirefox) {
-          target = (vertical) ? "translate3d(0," + target + ",0)" : "translate3d(" + (parseInt(target)+'px') + ",0,0)";
+          target = (vertical) ? "translate3d(0," + target + ",0)" : "translate3d(" + (parseInt(target) + 'px') + ",0,0)";
         } else {
-          target = (vertical) ? "translate3d(0," + target + ",0)" : "translate3d(" + ((slider.vars.rtl?-1:1)*parseInt(target)+'px') + ",0,0)";
+          target = (vertical) ? "translate3d(0," + target + ",0)" : "translate3d(" + ((slider.vars.rtl ? -1 : 1) * parseInt(target) + 'px') + ",0,0)";
         }
-        dur = (dur !== undefined) ? (dur/1000) + "s" : "0s";
+        dur = (dur !== undefined) ? (dur / 1000) + "s" : "0s";
         slider.container.css("-" + slider.pfx + "-transition-duration", dur);
-         slider.container.css("transition-duration", dur);
+        slider.container.css("transition-duration", dur);
       }
 
       slider.args[slider.prop] = target;
-      if (slider.transitions || dur === undefined) { slider.container.css(slider.args); }
+      if (slider.transitions || dur === undefined) {
+        slider.container.css(slider.args);
+      }
 
-      slider.container.css('transform',target);
+      slider.container.css('transform', target);
     };
 
-    slider.setup = function(type) {
+    slider.setup = function (type) {
       // SLIDE:
       if (!fade) {
         var sliderOffset, arr;
 
         if (type === "init") {
-          slider.viewport = $('<div class="' + namespace + 'viewport"></div>').css({"overflow": "hidden", "position": "relative"}).appendTo(slider).append(slider.container);
+          slider.viewport = $('<div class="' + namespace + 'viewport"></div>').css({
+            "overflow": "hidden",
+            "position": "relative"
+          }).appendTo(slider).append(slider.container);
           // INFINITE LOOP:
           slider.cloneCount = 0;
           slider.cloneOffset = 0;
@@ -955,9 +1027,11 @@
           slider.cloneCount = 2;
           slider.cloneOffset = 1;
           // clear out old clones
-          if (type !== "init") { slider.container.find('.clone').remove(); }
+          if (type !== "init") {
+            slider.container.find('.clone').remove();
+          }
           slider.container.append(methods.uniqueID(slider.slides.first().clone().addClass('clone')).attr('aria-hidden', 'true'))
-                          .prepend(methods.uniqueID(slider.slides.last().clone().addClass('clone')).attr('aria-hidden', 'true'));
+            .prepend(methods.uniqueID(slider.slides.last().clone().addClass('clone')).attr('aria-hidden', 'true'));
         }
         slider.newSlides = $(slider.vars.selector, slider);
 
@@ -965,7 +1039,7 @@
         // VERTICAL:
         if (vertical && !carousel) {
           slider.container.height((slider.count + slider.cloneCount) * 200 + "%").css("position", "absolute").width("100%");
-          setTimeout(function(){
+          setTimeout(function () {
             slider.newSlides.css({"display": "block"});
             slider.doMath();
             slider.viewport.height(slider.h);
@@ -974,61 +1048,95 @@
         } else {
           slider.container.width((slider.count + slider.cloneCount) * 200 + "%");
           slider.setProps(sliderOffset * slider.computedW, "init");
-          setTimeout(function(){
+          setTimeout(function () {
             slider.doMath();
-          if(slider.vars.rtl){
-            if (slider.isFirefox) {
-              slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
+            if (slider.vars.rtl) {
+              if (slider.isFirefox) {
+                slider.newSlides.css({
+                  "width": slider.computedW,
+                  "marginRight": slider.computedM,
+                  "float": "right",
+                  "display": "block"
+                });
+              } else {
+                slider.newSlides.css({
+                  "width": slider.computedW,
+                  "marginRight": slider.computedM,
+                  "float": "left",
+                  "display": "block"
+                });
+              }
+
             } else {
-              slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "left", "display": "block"});
-            }
-              
-           }
-            else{
-              slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "left", "display": "block"});
+              slider.newSlides.css({
+                "width": slider.computedW,
+                "marginRight": slider.computedM,
+                "float": "left",
+                "display": "block"
+              });
             }
             // SMOOTH HEIGHT:
-            if (slider.vars.smoothHeight) { methods.smoothHeight(); }
+            if (slider.vars.smoothHeight) {
+              methods.smoothHeight();
+            }
           }, (type === "init") ? 100 : 0);
         }
       } else { // FADE:
-        if(slider.vars.rtl){
+        if (slider.vars.rtl) {
           slider.slides.css({"width": "100%", "float": 'right', "marginLeft": "-100%", "position": "relative"});
-        }
-        else{
+        } else {
           slider.slides.css({"width": "100%", "float": 'left', "marginRight": "-100%", "position": "relative"});
         }
         if (type === "init") {
           if (!touch) {
             //slider.slides.eq(slider.currentSlide).fadeIn(slider.vars.animationSpeed, slider.vars.easing);
             if (slider.vars.fadeFirstSlide == false) {
-              slider.slides.css({ "opacity": 0, "display": "block", "zIndex": 1 }).eq(slider.currentSlide).css({"zIndex": 2}).css({"opacity": 1});
+              slider.slides.css({
+                "opacity": 0,
+                "display": "block",
+                "zIndex": 1
+              }).eq(slider.currentSlide).css({"zIndex": 2}).css({"opacity": 1});
             } else {
-              slider.slides.css({ "opacity": 0, "display": "block", "zIndex": 1 }).eq(slider.currentSlide).css({"zIndex": 2}).animate({"opacity": 1},slider.vars.animationSpeed,slider.vars.easing);
+              slider.slides.css({
+                "opacity": 0,
+                "display": "block",
+                "zIndex": 1
+              }).eq(slider.currentSlide).css({"zIndex": 2}).animate({"opacity": 1}, slider.vars.animationSpeed, slider.vars.easing);
             }
           } else {
-            slider.slides.css({ "opacity": 0, "display": "block", "webkitTransition": "opacity " + slider.vars.animationSpeed / 1000 + "s ease", "zIndex": 1 }).eq(slider.currentSlide).css({ "opacity": 1, "zIndex": 2});
+            slider.slides.css({
+              "opacity": 0,
+              "display": "block",
+              "webkitTransition": "opacity " + slider.vars.animationSpeed / 1000 + "s ease",
+              "zIndex": 1
+            }).eq(slider.currentSlide).css({"opacity": 1, "zIndex": 2});
           }
         }
         // SMOOTH HEIGHT:
-        if (slider.vars.smoothHeight) { methods.smoothHeight(); }
+        if (slider.vars.smoothHeight) {
+          methods.smoothHeight();
+        }
       }
       // !CAROUSEL:
       // CANDIDATE: active slide
-      if (!carousel) { slider.slides.removeClass(namespace + "active-slide").eq(slider.currentSlide).addClass(namespace + "active-slide"); }
+      if (!carousel) {
+        slider.slides.removeClass(namespace + "active-slide").eq(slider.currentSlide).addClass(namespace + "active-slide");
+      }
 
       //FlexSlider: init() Callback
       slider.vars.init(slider);
     };
 
-    slider.doMath = function() {
+    slider.doMath = function () {
       var slide = slider.slides.first(),
-          slideMargin = slider.vars.itemMargin,
-          minItems = slider.vars.minItems,
-          maxItems = slider.vars.maxItems;
+        slideMargin = slider.vars.itemMargin,
+        minItems = slider.vars.minItems,
+        maxItems = slider.vars.maxItems;
 
-      slider.w = (slider.viewport===undefined) ? slider.width() : slider.viewport.width();
-      if (slider.isFirefox) { slider.w = slider.width(); }
+      slider.w = (slider.viewport === undefined) ? slider.width() : slider.viewport.width();
+      if (slider.isFirefox) {
+        slider.w = slider.width();
+      }
       slider.h = slide.height();
       slider.boxPadding = slide.outerWidth() - slide.width();
 
@@ -1038,16 +1146,16 @@
         slider.itemM = slideMargin;
         slider.minW = (minItems) ? minItems * slider.itemT : slider.w;
         slider.maxW = (maxItems) ? (maxItems * slider.itemT) - slideMargin : slider.w;
-        slider.itemW = (slider.minW > slider.w) ? (slider.w - (slideMargin * (minItems - 1)))/minItems :
-                       (slider.maxW < slider.w) ? (slider.w - (slideMargin * (maxItems - 1)))/maxItems :
-                       (slider.vars.itemWidth > slider.w) ? slider.w : slider.vars.itemWidth;
+        slider.itemW = (slider.minW > slider.w) ? (slider.w - (slideMargin * (minItems - 1))) / minItems :
+          (slider.maxW < slider.w) ? (slider.w - (slideMargin * (maxItems - 1))) / maxItems :
+            (slider.vars.itemWidth > slider.w) ? slider.w : slider.vars.itemWidth;
 
-        slider.visible = Math.floor(slider.w/(slider.itemW));
-        slider.move = (slider.vars.move > 0 && slider.vars.move < slider.visible ) ? slider.vars.move : slider.visible;
-        slider.pagingCount = Math.ceil(((slider.count - slider.visible)/slider.move) + 1);
-        slider.last =  slider.pagingCount - 1;
+        slider.visible = Math.floor(slider.w / (slider.itemW));
+        slider.move = (slider.vars.move > 0 && slider.vars.move < slider.visible) ? slider.vars.move : slider.visible;
+        slider.pagingCount = Math.ceil(((slider.count - slider.visible) / slider.move) + 1);
+        slider.last = slider.pagingCount - 1;
         slider.limit = (slider.pagingCount === 1) ? 0 :
-                       (slider.vars.itemWidth > slider.w) ? (slider.itemW * (slider.count - 1)) + (slideMargin * (slider.count - 1)) : ((slider.itemW + slideMargin) * slider.count) - slider.w - slideMargin;
+          (slider.vars.itemWidth > slider.w) ? (slider.itemW * (slider.count - 1)) + (slideMargin * (slider.count - 1)) : ((slider.itemW + slideMargin) * slider.count) - slider.w - slideMargin;
       } else {
         slider.itemW = slider.w;
         slider.itemM = slideMargin;
@@ -1058,7 +1166,7 @@
       slider.computedM = slider.itemM;
     };
 
-    slider.update = function(pos, action) {
+    slider.update = function (pos, action) {
       slider.doMath();
 
       // update currentSlide and slider.animatingTo if necessary
@@ -1084,11 +1192,13 @@
         }
       }
       // update directionNav
-      if (slider.vars.directionNav) { methods.directionNav.update(); }
+      if (slider.vars.directionNav) {
+        methods.directionNav.update();
+      }
 
     };
 
-    slider.addSlide = function(obj, pos) {
+    slider.addSlide = function (obj, pos) {
       var $obj = $(obj);
 
       slider.count += 1;
@@ -1112,7 +1222,7 @@
       //FlexSlider: added() Callback
       slider.vars.added(slider);
     };
-    slider.removeSlide = function(obj) {
+    slider.removeSlide = function (obj) {
       var pos = (isNaN(obj)) ? slider.slides.index($(obj)) : obj;
 
       // update count
@@ -1144,9 +1254,9 @@
   };
 
   // Ensure the slider isn't focussed if the window loses focus.
-  $( window ).blur( function ( e ) {
+  $(window).blur(function (e) {
     focused = false;
-  }).focus( function ( e ) {
+  }).focus(function (e) {
     focused = true;
   });
 
@@ -1210,29 +1320,40 @@
     isFirefox: false,             // {NEW} Boolean: Set to true when Firefox is the browser used.
 
     // Callback API
-    start: function(){},            //Callback: function(slider) - Fires when the slider loads the first slide
-    before: function(){},           //Callback: function(slider) - Fires asynchronously with each slider animation
-    after: function(){},            //Callback: function(slider) - Fires after each slider animation completes
-    end: function(){},              //Callback: function(slider) - Fires when the slider reaches the last slide (asynchronous)
-    added: function(){},            //{NEW} Callback: function(slider) - Fires after a slide is added
-    removed: function(){},           //{NEW} Callback: function(slider) - Fires after a slide is removed
-    init: function() {},             //{NEW} Callback: function(slider) - Fires after the slider is initially setup
-  rtl: false             //{NEW} Boolean: Whether or not to enable RTL mode
+    start: function () {
+    },            //Callback: function(slider) - Fires when the slider loads the first slide
+    before: function () {
+    },           //Callback: function(slider) - Fires asynchronously with each slider animation
+    after: function () {
+    },            //Callback: function(slider) - Fires after each slider animation completes
+    end: function () {
+    },              //Callback: function(slider) - Fires when the slider reaches the last slide (asynchronous)
+    added: function () {
+    },            //{NEW} Callback: function(slider) - Fires after a slide is added
+    removed: function () {
+    },           //{NEW} Callback: function(slider) - Fires after a slide is removed
+    init: function () {
+    },             //{NEW} Callback: function(slider) - Fires after the slider is initially setup
+    rtl: false             //{NEW} Boolean: Whether or not to enable RTL mode
   };
 
   //FlexSlider: Plugin Function
-  $.fn.flexslider = function(options) {
-    if (options === undefined) { options = {}; }
+  $.fn.flexslider = function (options) {
+    if (options === undefined) {
+      options = {};
+    }
 
     if (typeof options === "object") {
-      return this.each(function() {
+      return this.each(function () {
         var $this = $(this),
-            selector = (options.selector) ? options.selector : ".slides > li",
-            $slides = $this.find(selector);
+          selector = (options.selector) ? options.selector : ".slides > li",
+          $slides = $this.find(selector);
 
-      if ( ( $slides.length === 1 && options.allowOneSlide === false ) || $slides.length === 0 ) {
+        if (($slides.length === 1 && options.allowOneSlide === false) || $slides.length === 0) {
           $slides.fadeIn(400);
-          if (options.start) { options.start($this); }
+          if (options.start) {
+            options.start($this);
+          }
         } else if ($this.data('flexslider') === undefined) {
           new $.flexslider(this, options);
         }
@@ -1241,13 +1362,26 @@
       // Helper strings to quickly perform functions on the slider
       var $slider = $(this).data('flexslider');
       switch (options) {
-        case "play": $slider.play(); break;
-        case "pause": $slider.pause(); break;
-        case "stop": $slider.stop(); break;
-        case "next": $slider.flexAnimate($slider.getTarget("next"), true); break;
+        case "play":
+          $slider.play();
+          break;
+        case "pause":
+          $slider.pause();
+          break;
+        case "stop":
+          $slider.stop();
+          break;
+        case "next":
+          $slider.flexAnimate($slider.getTarget("next"), true);
+          break;
         case "prev":
-        case "previous": $slider.flexAnimate($slider.getTarget("prev"), true); break;
-        default: if (typeof options === "number") { $slider.flexAnimate(options, true); }
+        case "previous":
+          $slider.flexAnimate($slider.getTarget("prev"), true);
+          break;
+        default:
+          if (typeof options === "number") {
+            $slider.flexAnimate(options, true);
+          }
       }
     }
   };

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -340,37 +340,39 @@
       },
       directionNav: {
         setup: function() {
-          var directionNavScaffold = $('<ul class="' + namespace + 'direction-nav"><li class="' + namespace + 'nav-prev"><a class="' + namespace + 'prev" href="#">' + slider.vars.prevText + '</a></li><li class="' + namespace + 'nav-next"><a class="' + namespace + 'next" href="#">' + slider.vars.nextText + '</a></li></ul>');
+          if (slider.pagingCount > 1) {
+            var directionNavScaffold = $('<ul class="' + namespace + 'direction-nav"><li class="' + namespace + 'nav-prev"><a class="' + namespace + 'prev" href="#">' + slider.vars.prevText + '</a></li><li class="' + namespace + 'nav-next"><a class="' + namespace + 'next" href="#">' + slider.vars.nextText + '</a></li></ul>');
 
-          // CUSTOM DIRECTION NAV:
-          if (slider.customDirectionNav) {
-            slider.directionNav = slider.customDirectionNav;
-          // CONTROLSCONTAINER:
-          } else if (slider.controlsContainer) {
-            $(slider.controlsContainer).append(directionNavScaffold);
-            slider.directionNav = $('.' + namespace + 'direction-nav li a', slider.controlsContainer);
-          } else {
-            slider.append(directionNavScaffold);
-            slider.directionNav = $('.' + namespace + 'direction-nav li a', slider);
+            // CUSTOM DIRECTION NAV:
+            if (slider.customDirectionNav) {
+              slider.directionNav = slider.customDirectionNav;
+            // CONTROLSCONTAINER:
+            } else if (slider.controlsContainer) {
+              $(slider.controlsContainer).append(directionNavScaffold);
+              slider.directionNav = $('.' + namespace + 'direction-nav li a', slider.controlsContainer);
+            } else {
+              slider.append(directionNavScaffold);
+              slider.directionNav = $('.' + namespace + 'direction-nav li a', slider);
+            }
+
+            methods.directionNav.update();
+
+            slider.directionNav.bind(eventType, function(event) {
+              event.preventDefault();
+              var target;
+
+              if (watchedEvent === "" || watchedEvent === event.type) {
+                target = ($(this).hasClass(namespace + 'next')) ? slider.getTarget('next') : slider.getTarget('prev');
+                slider.flexAnimate(target, slider.vars.pauseOnAction);
+              }
+
+              // setup flags to prevent event duplication
+              if (watchedEvent === "") {
+                watchedEvent = event.type;
+              }
+              methods.setToClearWatchedEvent();
+            });
           }
-
-          methods.directionNav.update();
-
-          slider.directionNav.bind(eventType, function(event) {
-            event.preventDefault();
-            var target;
-
-            if (watchedEvent === "" || watchedEvent === event.type) {
-              target = ($(this).hasClass(namespace + 'next')) ? slider.getTarget('next') : slider.getTarget('prev');
-              slider.flexAnimate(target, slider.vars.pauseOnAction);
-            }
-
-            // setup flags to prevent event duplication
-            if (watchedEvent === "") {
-              watchedEvent = event.type;
-            }
-            methods.setToClearWatchedEvent();
-          });
         },
         update: function() {
           var disabledClass = namespace + 'disabled';


### PR DESCRIPTION
Our accessibility people came back with this suggestion for screen readers:

"The pager (the dots under the slideshow when there is more than one slide) need labels (or ARIA labels). Currently a screed reader reads them as "List of 4 items. 1 group, 2. 2 group, 3..." etc. in VoiceOver. In JAWS sr says “link clickable 1, link clickable 2" It's not clear to the user what these links refer to. 

This is the pager on https://newdesign-new-fitness.ws.asu.edu/:
<ol class="flex-control-nav flex-control-paging">
<li><a class="">1</a></li>
<li><a class="">2</a></li>
<li><a class="flex-active">3</a></li>
<li><a class="">4</a></li>
</ol>

You can either change the link wording:
<li><a class="">Slide 1</a></li>
or add an aria-label:
<li><a class="" aria-label="Slide">1</a></li>
to identify the link."

=======================

I didn't update the minified file (build process handles this?)