### PR TITLE
docs: Fix simple typo, accomdate -> accommodate

### DIFF
--- a/demo/js/jquery.flexslider.js
+++ b/demo/js/jquery.flexslider.js
@@ -1104,7 +1104,7 @@
 
       // update slider.slides
       slider.slides = $(slider.vars.selector + ':not(.clone)', slider);
-      // re-setup the slider to accomdate new slide
+      // re-setup the slider to accommodate new slide
       slider.setup();
 
       //FlexSlider: added() Callback
@@ -1130,7 +1130,7 @@
 
       // update slider.slides
       slider.slides = $(slider.vars.selector + ':not(.clone)', slider);
-      // re-setup the slider to accomdate new slide
+      // re-setup the slider to accommodate new slide
       slider.setup();
 
       // FlexSlider: removed() Callback

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -1104,7 +1104,7 @@
 
       // update slider.slides
       slider.slides = $(slider.vars.selector + ':not(.clone)', slider);
-      // re-setup the slider to accomdate new slide
+      // re-setup the slider to accommodate new slide
       slider.setup();
 
       //FlexSlider: added() Callback
@@ -1130,7 +1130,7 @@
 
       // update slider.slides
       slider.slides = $(slider.vars.selector + ':not(.clone)', slider);
-      // re-setup the slider to accomdate new slide
+      // re-setup the slider to accommodate new slide
       slider.setup();
 
       // FlexSlider: removed() Callback


### PR DESCRIPTION
There is a small typo in demo/js/jquery.flexslider.js, jquery.flexslider.js.

Should read `accommodate` rather than `accomdate`.

