### PR TITLE
Fix #25641: Gallery thumbnails without size

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -243,7 +243,11 @@
               
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
               if ( slider.vars.controlNav === "thumbnails" ) {
-                item = $( '<img/>' ).attr( 'src', slide.attr( 'data-thumb' ) );
+                item = $( '<img/>' )
+                .attr( 'width', parseInt( slide.width() ) )
+                .attr( 'height', parseInt( slide.height() ) )
+                .attr( 'alt', slide.attr( 'alt' ) )
+                .attr( 'src', slide.attr( 'data-thumb' ) );
               }
               
               if ( '' !== slide.attr( 'data-thumb-alt' ) ) {

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -244,8 +244,8 @@
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
               if ( slider.vars.controlNav === "thumbnails" ) {
                 item = $( '<img/>' )
-                .attr( 'width', parseInt( slide.width() ) )
-                .attr( 'height', parseInt( slide.height() ) )
+                .attr( 'width', parseInt( parseInt( slider.width() ) / slider.pagingCount ) )
+                .attr( 'height', parseInt( parseInt( slider.width() ) / slider.pagingCount ) )
                 .attr( 'alt', slide.attr( 'alt' ) )
                 .attr( 'src', slide.attr( 'data-thumb' ) );
               }


### PR DESCRIPTION
This should silence the lighthouse warnings, based on the code of https://github.com/woocommerce/woocommerce/issues/25461#issuecomment-845673185

If you want to use this version in your theme, put this js file in theme:

```
wp_deregister_script('flexslider');
wp_register_script( 'flexslider', get_stylesheet_directory_uri() . '/js/jquery.flexslider.js', array( 'jquery' ) );
```